### PR TITLE
feat(SBFTree): added operators logic in SBFTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Note : By default. Everything is indexed.
 
 ### Table of Contents
  - [Installation](#installation)
+ - [Release Notes](#release-notes)
  - [Usage](#usage)
  - [Documentation](#documentation)
     - [Events](/doc/events.md)
@@ -28,6 +29,10 @@ Note : By default. Everything is indexed.
 ## Installation 
 
 `npm install sbtree`
+
+## Release Notes
+
+See the [release notes](RELEASE.md)
 
 ## Usage
 
@@ -52,7 +57,9 @@ const start = async function () {
   await tree.insertDocuments(doc2);
 
   // [ { _id: '507f1f77bcf86cd799439011', name: 'Alex', age: 28 } ]
-  const search = await tree.findDocuments({age:28});
+  const searchLte = await tree.findDocuments({age:{$lte:28}});
+  // [ { _id: '507f1f77bcf86cd799439011', name: 'Alex', age: 28 } ] -> equivalent {age:{$eq:28}}
+  const searchEq = await tree.findDocuments({age:28});
 
   // [ { _id: '507f1f77bcf86cd799439011', name: 'Alex', age: 28 } ]
   const get = await tree.getDocument(doc._id);
@@ -89,8 +96,11 @@ That basically allow us to deal with bigger dataset.
 For development purpose, I decided that being able to console view the object without all the nested parent thing was handy a clean.   
 That's the only reason. But Node V.12 is old enough already, no point sticking to the past.  
 
-
 ### Caveat :
 
 Right now, due to FS adapter requiring reference from tree for autoload.   
 And adapter being called beforehand (for props passing). You need to listen for the event `.on('ready')` first.   
+
+### Others links 
+
+- [TODO](TODO.md)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+## 1.1.0 
+
+TODO
+
+## 1.0.0 
+
+- [#8327df9](https://github.com/Alex-Werner/SBTree/commit/8327df9eb268ccb4d8fc4fcfae18a44ea0fc9361) - Perf benchmark within travis/mocha
+- [#1a0941b](https://github.com/Alex-Werner/SBTree/commit/1a0941b5caa06b3bc705db6bdf4b8a5d055e6670) - FSAdapter load/save
+- [#55f1de0](https://github.com/Alex-Werner/SBTree/commit/55f1de059076f8b93557a12a20a1c136fc0b565d) -  Queue system + locking for FSAdapter (see [FSLockJS](https://github.com/Alex-Werner/FSLockJS))
+- FS Adapter + In Memory Adapter
+- Allow document to not contains all field
+- Allow documents to not contains _id
+- Basic Tree structure + One tree per Field
+- Basic documentation + tests

--- a/TODO.md
+++ b/TODO.md
@@ -8,3 +8,4 @@
 - [ ] Allow to excludes certains indexes or switch from all indexed to a specify index only ?
 - [ ] Allow to set some indexes uniques.
 - [ ] Do we want to allow them to allow duplicate _id ?
+- [ ] Case sentitivity

--- a/TODO.md
+++ b/TODO.md
@@ -8,4 +8,5 @@
 - [ ] Allow to excludes certains indexes or switch from all indexed to a specify index only ?
 - [ ] Allow to set some indexes uniques.
 - [ ] Do we want to allow them to allow duplicate _id ?
-- [ ] Case sentitivity
+- [ ] Case sentitivity (the transform method need to be deterministic. It won't touch the value added in documents.);
+- [ ] LRU Caching on the most requested keys

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -11,13 +11,13 @@ N.B : Not available yet. Only strict comparison. This documentation documents fo
 |--------------	|-------------------------------------------------------------------------	|------------------------------------------------	|
 | implicit $eq 	| Standard query. Matches documents that equal to the specified value.    	| `.findDocuments({age:33})`                     	|
 | $eq          	| Same as above. But explicit.                                            	| `.findDocuments({age:{$eq:33})`                	|
-| $ne          	| Matches documents that are NOT equal to specified value.                	| `.findDocuments({age:{$ne:33})`                     	|
+| $ne          	| Matches documents that are NOT equal to specified value.                	| `.findDocuments({age:{$ne:33})`               	|
 | $gt          	| Matches documents that are greater than a specified value.              	| `.findDocuments({age:{$gt:18})`                	|
 | $gte         	| Matches documents that are greater or equal than a specified value.     	| `.findDocuments({age:{$gte:18})`               	|
 | $lt          	| Matches documents that are less than a specified value.                 	| `.findDocuments({age:{$lt:50})`                	|
 | $lte         	| Matches documents that are less than or equals a specified value.       	| `.findDocuments({age:{$lte:50})`               	|
-| $in          	| Matches documents that have one elements in the specified array.        	| `.findDocuments({country:{$in:"France"})`      	|
-| $nin         	| Matches documents that do not have any elements of the specified array. 	| `.findDocuments({country:{$nin:"Antarctica"})` 	|
+| $in (TODO)   	| Matches documents that have one elements in the specified array.        	| `.findDocuments({country:{$in:"France"})`      	|
+| $nin (TODO) 	| Matches documents that do not have any elements of the specified array. 	| `.findDocuments({country:{$nin:"Antarctica"})` 	|
 
 
 ### Additionals 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -11,7 +11,7 @@ N.B : Not available yet. Only strict comparison. This documentation documents fo
 |--------------	|-------------------------------------------------------------------------	|------------------------------------------------	|
 | implicit $eq 	| Standard query. Matches documents that equal to the specified value.    	| `.findDocuments({age:33})`                     	|
 | $eq          	| Same as above. But explicit.                                            	| `.findDocuments({age:{$eq:33})`                	|
-| $ne          	| Matches documents that are NOT equal to specified value.                	| `.findDocuments({$ne:33})`                     	|
+| $ne          	| Matches documents that are NOT equal to specified value.                	| `.findDocuments({age:{$ne:33})`                     	|
 | $gt          	| Matches documents that are greater than a specified value.              	| `.findDocuments({age:{$gt:18})`                	|
 | $gte         	| Matches documents that are greater or equal than a specified value.     	| `.findDocuments({age:{$gte:18})`               	|
 | $lt          	| Matches documents that are less than a specified value.                 	| `.findDocuments({age:{$lt:50})`                	|

--- a/src/adapters/FsAdapter/FsAdapter.js
+++ b/src/adapters/FsAdapter/FsAdapter.js
@@ -40,6 +40,7 @@ FsAdapter.prototype.attachParent = require('./methods/attachParent');
 FsAdapter.prototype.addInLeaf = require('./methods/addInLeaf')
 FsAdapter.prototype.createLeaf = require('./methods/createLeaf')
 FsAdapter.prototype.findInLeaf = require('./methods/findInLeaf')
+FsAdapter.prototype.findAllInLeaf = require('./methods/findAllInLeaf')
 FsAdapter.prototype.getDocument = require('./methods/getDocument')
 FsAdapter.prototype.insertSortedInLeaf = require('./methods/insertSortedInLeaf')
 FsAdapter.prototype.loadDatabase = require('./methods/loadDatabase')

--- a/src/adapters/FsAdapter/methods/findAllInLeaf.js
+++ b/src/adapters/FsAdapter/methods/findAllInLeaf.js
@@ -1,0 +1,10 @@
+module.exports = async function findAllInLeaf(leafName){
+
+  let {keys} = await this.openLeafData(leafName);
+  if(!keys){
+    console.error(`Leafname ${leafName} was not present, had to recreate`)
+    await this.createLeaf(leafName);
+    return this.findAllInLeaf(leafName);
+  }
+  return this.leafs[leafName].meta.identifiers;
+}

--- a/src/adapters/FsAdapter/methods/findInLeaf.js
+++ b/src/adapters/FsAdapter/methods/findInLeaf.js
@@ -1,23 +1,52 @@
-function getAllIndexes(arr, val) {
-  let indexes = [], i = -1;
-  while ((i = arr.indexOf(val, i+1)) !== -1){
-    indexes.push(i);
-  }
-  return indexes;
-}
-module.exports = async function findInLeaf(leafName, key){
-
+const getStrictMatchingKeys = require('./ops/getStrictMatchingKeys');
+const lowerThanKeys = require('./ops/lowerThanKeys');
+const greaterThanKeys = require('./ops/greaterThanKeys');
+module.exports = async function findInLeaf(leafName, key, op = '$eq') {
   let {keys} = await this.openLeafData(leafName);
-  if(!keys){
+  if (!keys) {
     console.error(`Leafname ${leafName} was not present, had to recreate`)
     await this.createLeaf(leafName);
-    return this.findInLeaf(leafName, key);
+    return this.findInLeaf(leafName, key, op);
   }
-  const indexes = getAllIndexes(keys, key);
-  if(!indexes.length){
-    return [];
+  const strictMatchingKeys = getStrictMatchingKeys(keys, key);
+
+  switch (op) {
+    case "$eq":
+      if(!strictMatchingKeys.length){
+        return [];
+      }
+      const start = strictMatchingKeys[0];
+      const end = strictMatchingKeys[0]+strictMatchingKeys.length;
+      return this.leafs[leafName].meta.identifiers.slice(start, end);
+    case "$lte":
+      let resLte = [];
+      resLte = resLte.concat(await this.findInLeaf(leafName, key, '$lt'));
+      resLte = resLte.concat(await this.findInLeaf(leafName, key, '$eq'));
+      return resLte;
+    case "$gte":
+      let resGte = [];
+      resGte = resGte.concat(await this.findInLeaf(leafName, key, '$eq'));
+      resGte = resGte.concat(await this.findInLeaf(leafName, key, '$gt'));
+      return resGte;
+    case "$lt":
+      if(strictMatchingKeys.length){
+        const localIndex = keys.indexOf(key);
+        return (localIndex===0) ? [] : this.leafs[leafName].meta.identifiers.slice(0, localIndex);
+      }else{
+        const ltKeys = lowerThanKeys(keys, key);
+        return this.leafs[leafName].meta.identifiers.slice(0, ltKeys.length);
+      }
+    case "$gt":
+      if(strictMatchingKeys.length){
+        const localIndex = keys.indexOf(key);
+        return (localIndex===-1) ? [] : this.leafs[leafName].meta.identifiers.slice(localIndex+strictMatchingKeys.length);
+      }else{
+        const _keys = greaterThanKeys(keys, key);
+        const len = (_keys.length<=0) ? 0 : _keys.length;
+        return (len===0) ? [] :this.leafs[leafName].meta.identifiers.slice(-len);
+      }
+    default:
+      throw new Error(`Unsupported operator ${op}`);
   }
-  const start = indexes[0];
-  const end = indexes[0]+indexes.length;
-  return this.leafs[leafName].meta.identifiers.slice(start, end);
+
 }

--- a/src/adapters/FsAdapter/methods/loadDatabase.js
+++ b/src/adapters/FsAdapter/methods/loadDatabase.js
@@ -15,7 +15,6 @@ module.exports = async function loadDatabase(){
             this.leafs[leafName] = {name:leafName, meta:new LeafMeta(leaf.meta)};
         })
         await this.parent.loadState(tree);
-
     }
 
     // console.dir(this.parent, {depth:null});

--- a/src/adapters/FsAdapter/methods/ops/getStrictMatchingKeys.js
+++ b/src/adapters/FsAdapter/methods/ops/getStrictMatchingKeys.js
@@ -1,0 +1,8 @@
+function getStrictMatchingKeys(arr, val) {
+  let indexes = [], i = -1;
+  while ((i = arr.indexOf(val, i + 1)) !== -1) {
+    indexes.push(i);
+  }
+  return indexes;
+}
+module.exports = getStrictMatchingKeys;

--- a/src/adapters/FsAdapter/methods/ops/greaterThanKeys.js
+++ b/src/adapters/FsAdapter/methods/ops/greaterThanKeys.js
@@ -1,0 +1,4 @@
+function greaterThanKeys(arr, val) {
+  return arr.filter((el)=> el>val)
+};
+module.exports = greaterThanKeys;

--- a/src/adapters/FsAdapter/methods/ops/lowerThanKeys.js
+++ b/src/adapters/FsAdapter/methods/ops/lowerThanKeys.js
@@ -1,0 +1,4 @@
+function lowerThanKeys(arr, val) {
+  return arr.filter((el)=> el<val)
+};
+module.exports = lowerThanKeys;

--- a/src/adapters/MemoryAdapter/MemoryAdapter.js
+++ b/src/adapters/MemoryAdapter/MemoryAdapter.js
@@ -7,6 +7,7 @@ class MemoryAdapter {
 };
 MemoryAdapter.prototype.addInLeaf = require('./methods/addInLeaf')
 MemoryAdapter.prototype.createLeaf = require('./methods/createLeaf')
+MemoryAdapter.prototype.findAllInLeaf = require('./methods/findAllInLeaf')
 MemoryAdapter.prototype.findInLeaf = require('./methods/findInLeaf')
 MemoryAdapter.prototype.getDocument = require('./methods/getDocument')
 MemoryAdapter.prototype.openLeaf = require('./methods/openLeaf')

--- a/src/adapters/MemoryAdapter/methods/findAllInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/findAllInLeaf.js
@@ -1,0 +1,3 @@
+module.exports = async function findAllInLeaf(leafName){
+  return this.leafs[leafName].meta.identifiers;
+}

--- a/src/adapters/MemoryAdapter/methods/findInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/findInLeaf.js
@@ -1,16 +1,45 @@
-function getAllIndexes(arr, val) {
-  let indexes = [], i = -1;
-  while ((i = arr.indexOf(val, i+1)) !== -1){
-    indexes.push(i);
+const getStrictMatchingKeys = require('./ops/getStrictMatchingKeys');
+const lowerThanKeys = require('./ops/lowerThanKeys');
+const greaterThanKeys = require('./ops/greaterThanKeys');
+module.exports = async function findInLeaf(leafName, key, op = '$eq'){
+  const strictMatchingKeys = getStrictMatchingKeys(this.leafs[leafName].data.keys, key);
+  switch (op) {
+    case "$eq":
+      if(!strictMatchingKeys.length){
+        return [];
+      }
+      const start = strictMatchingKeys[0];
+      const end = strictMatchingKeys[0]+strictMatchingKeys.length;
+      return this.leafs[leafName].meta.identifiers.slice(start, end);
+      break;
+    case "$lte":
+      let resLte = [];
+      resLte = resLte.concat(await this.findInLeaf(leafName, key, '$lt'));
+      resLte = resLte.concat(await this.findInLeaf(leafName, key, '$eq'));
+      return resLte;
+    case "$lt":
+      if(strictMatchingKeys.length){
+        const localIndex = this.leafs[leafName].data.keys.indexOf(key);
+        return (localIndex===0) ? [] : this.leafs[leafName].meta.identifiers.slice(0, localIndex-1);
+      }else{
+        const keys = lowerThanKeys(this.leafs[leafName].data.keys, key);
+        return this.leafs[leafName].meta.identifiers.slice(0, keys.length);
+      }
+    case "$gt":
+      if(strictMatchingKeys.length){
+        const localIndex = this.leafs[leafName].data.keys.indexOf(key);
+        return (localIndex===-1) ? [] : this.leafs[leafName].meta.identifiers.slice(localIndex+strictMatchingKeys.length);
+      }else{
+        const keys = greaterThanKeys(this.leafs[leafName].data.keys, key);
+        const len = (keys.length<=0) ? 0 : keys.length;
+        return (len===0) ? [] :this.leafs[leafName].meta.identifiers.slice(-len);
+      }
+    case "$gte":
+      let resGte = [];
+      resGte = resGte.concat(await this.findInLeaf(leafName, key, '$eq'));
+      resGte = resGte.concat(await this.findInLeaf(leafName, key, '$gt'));
+      return resGte;
+    default:
+      throw new Error(`Not supported op ${op}`);
   }
-  return indexes;
-}
-module.exports = async function findInLeaf(leafName, key){
-  const indexes = getAllIndexes(this.leafs[leafName].data.keys, key);
-  if(!indexes.length){
-    return [];
-  }
-  const start = indexes[0];
-  const end = indexes[0]+indexes.length;
-  return this.leafs[leafName].meta.identifiers.slice(start, end);
 }

--- a/src/adapters/MemoryAdapter/methods/ops/getStrictMatchingKeys.js
+++ b/src/adapters/MemoryAdapter/methods/ops/getStrictMatchingKeys.js
@@ -1,0 +1,8 @@
+function getStrictMatchingKeys(arr, val) {
+  let indexes = [], i = -1;
+  while ((i = arr.indexOf(val, i+1)) !== -1){
+    indexes.push(i);
+  }
+  return indexes;
+};
+module.exports = getStrictMatchingKeys;

--- a/src/adapters/MemoryAdapter/methods/ops/greaterThanKeys.js
+++ b/src/adapters/MemoryAdapter/methods/ops/greaterThanKeys.js
@@ -1,0 +1,4 @@
+function greaterThanKeys(arr, val) {
+  return arr.filter((el)=> el>val)
+};
+module.exports = greaterThanKeys;

--- a/src/adapters/MemoryAdapter/methods/ops/lowerThanKeys.js
+++ b/src/adapters/MemoryAdapter/methods/ops/lowerThanKeys.js
@@ -1,0 +1,4 @@
+function lowerThanKeys(arr, val) {
+  return arr.filter((el)=> el<val)
+};
+module.exports = lowerThanKeys;

--- a/src/types/SBFLeaf/SBFLeaf.js
+++ b/src/types/SBFLeaf/SBFLeaf.js
@@ -23,6 +23,7 @@ class SFBLeaf {
 };
 SFBLeaf.prototype.insert = require('./methods/insert');
 SFBLeaf.prototype.find = require('./methods/find');
+SFBLeaf.prototype.findAll = require('./methods/findAll');
 SFBLeaf.prototype.isFull = require('./methods/isFull');
 SFBLeaf.prototype.split = require('./methods/split');
 module.exports = SFBLeaf;

--- a/src/types/SBFLeaf/SBFLeaf.js
+++ b/src/types/SBFLeaf/SBFLeaf.js
@@ -24,6 +24,8 @@ class SFBLeaf {
 SFBLeaf.prototype.insert = require('./methods/insert');
 SFBLeaf.prototype.find = require('./methods/find');
 SFBLeaf.prototype.findAll = require('./methods/findAll');
+SFBLeaf.prototype.findLowerThan = require('./methods/findLowerThan');
+SFBLeaf.prototype.findGreaterThan = require('./methods/findGreaterThan');
 SFBLeaf.prototype.isFull = require('./methods/isFull');
 SFBLeaf.prototype.split = require('./methods/split');
 module.exports = SFBLeaf;

--- a/src/types/SBFLeaf/methods/findAll.js
+++ b/src/types/SBFLeaf/methods/findAll.js
@@ -1,0 +1,5 @@
+module.exports = async function findAll(){
+  const adapter = this.getParent().getAdapter();
+  const res = await adapter.findAllInLeaf(this.name);
+  return res
+}

--- a/src/types/SBFLeaf/methods/findGreaterThan.js
+++ b/src/types/SBFLeaf/methods/findGreaterThan.js
@@ -1,0 +1,6 @@
+module.exports = async function findGeaterThan(key, includeKey= false){
+  const op = includeKey ? '$gte' : '$gt';
+  const adapter = this.getParent().getAdapter();
+  const res = await adapter.findInLeaf(this.name,key, op);
+  return res
+}

--- a/src/types/SBFLeaf/methods/findLowerThan.js
+++ b/src/types/SBFLeaf/methods/findLowerThan.js
@@ -1,0 +1,6 @@
+module.exports = async function findLowerThan(key, includeKey= false){
+  const op = includeKey ? '$lte' : '$lt';
+  const adapter = this.getParent().getAdapter();
+  const res = await adapter.findInLeaf(this.name,key, op);
+  return res
+}

--- a/src/types/SBFNode/SBFNode.js
+++ b/src/types/SBFNode/SBFNode.js
@@ -43,6 +43,9 @@ class SBFNode {
 };
 SBFNode.prototype.attachLeaf = require('./methods/attachLeaf')
 SBFNode.prototype.find = require('./methods/find')
+SBFNode.prototype.findAll = require('./methods/findAll')
+SBFNode.prototype.findLowerThan = require('./methods/findLowerThan')
+SBFNode.prototype.findGreaterThan = require('./methods/findGreaterThan')
 SBFNode.prototype.getAdapter = require('./methods/getAdapter')
 SBFNode.prototype.getTreeOptions = require('./methods/getTreeOptions')
 SBFNode.prototype.insert = require('./methods/insert')

--- a/src/types/SBFNode/methods/find.js
+++ b/src/types/SBFNode/methods/find.js
@@ -12,12 +12,12 @@ module.exports = async function find(key){
   // if(leafIndex>0){
   //   console.log('oui', leafIndex)
   //   const left = this.childrens[leafIndex];
-  //   result = result.concat(result, await left.find(key));
+  //   result = result.concat(await left.find(key));
   // }
   // We also check the leaf nearby
   if(this.childrens.length>leafIndex+1){
     const right = this.childrens[leafIndex+1];
-    result = result.concat(result, await right.find(key));
+    result = result.concat(await right.find(key));
   }
 
   return result;

--- a/src/types/SBFNode/methods/findAll.js
+++ b/src/types/SBFNode/methods/findAll.js
@@ -6,8 +6,10 @@ module.exports = async function findAll(){
     p.push(child.findAll());
   });
 
-  await (Promise.all(p)).forEach((p)=>{
-    result = result.concat(p);
+  await Promise.all(p).then((res) => {
+    res.forEach((p) => {
+      result = result.concat(p);
+    })
   });
 
   return result;

--- a/src/types/SBFNode/methods/findAll.js
+++ b/src/types/SBFNode/methods/findAll.js
@@ -1,0 +1,14 @@
+module.exports = async function findAll(){
+  let result = [];
+
+  let p = [];
+  this.childrens.forEach((child)=>{
+    p.push(child.findAll());
+  });
+
+  await (Promise.all(p)).forEach((p)=>{
+    result = result.concat(p);
+  });
+
+  return result;
+}

--- a/src/types/SBFNode/methods/findGreaterThan.js
+++ b/src/types/SBFNode/methods/findGreaterThan.js
@@ -1,0 +1,22 @@
+async function findGreaterThan(key,includeKey=false) {
+  let result = [];
+
+  let leafIndex = 0;
+  this.keys.forEach((_key) => {
+    if (key <= _key) return;
+    leafIndex++;
+  });
+
+  result = result.concat(this.childrens.leafs[leafIndex].findGreaterThan(key, includeKey));
+  let p = [];
+  this.childrens.leafs.slice(leafIndex).forEach((child) => {
+    p.push(child.findAll())
+  });
+  await Promise.all(p).then((res) => {
+    res.forEach((p) => {
+      result = result.concat(p);
+    })
+  });
+  return result;
+}
+module.exports = findGreaterThan

--- a/src/types/SBFNode/methods/findLowerThan.js
+++ b/src/types/SBFNode/methods/findLowerThan.js
@@ -1,16 +1,17 @@
-module.exports = async
-
-function findLowerThan(key,includeKey=false) {
+async function findLowerThan(key,includeKey=false) {
   let result = [];
 
   let leafIndex = 0;
   let p = [];
-  this.keys.forEach((_key) => {
-    if (key <= _key) return;
-    leafIndex++;
-    p.push(this.childrens.findLowerThan(key, includeKey));
-  });
-
+  if(this.keys.length===0 && this.childrens.length===1){
+    p.push(this.childrens[0].findLowerThan(key, includeKey));
+  }else{
+    this.keys.forEach((_key) => {
+      if (key <= _key) return;
+      leafIndex++;
+      p.push(this.childrens[leafIndex].findLowerThan(key, includeKey));
+    });
+  }
   await Promise.all(p).then((res) => {
     res.forEach((p) => {
       result = result.concat(p);
@@ -18,3 +19,4 @@ function findLowerThan(key,includeKey=false) {
   });
   return result;
 }
+module.exports = findLowerThan

--- a/src/types/SBFNode/methods/findLowerThan.js
+++ b/src/types/SBFNode/methods/findLowerThan.js
@@ -1,0 +1,20 @@
+module.exports = async
+
+function findLowerThan(key,includeKey=false) {
+  let result = [];
+
+  let leafIndex = 0;
+  let p = [];
+  this.keys.forEach((_key) => {
+    if (key <= _key) return;
+    leafIndex++;
+    p.push(this.childrens.findLowerThan(key, includeKey));
+  });
+
+  await Promise.all(p).then((res) => {
+    res.forEach((p) => {
+      result = result.concat(p);
+    })
+  });
+  return result;
+}

--- a/src/types/SBFRoot/SBFRoot.js
+++ b/src/types/SBFRoot/SBFRoot.js
@@ -24,8 +24,8 @@ class SBFRoot {
 };
 SBFRoot.prototype.attachLeaf = require('./methods/attachLeaf')
 SBFRoot.prototype.find = require('./methods/find')
+SBFRoot.prototype.findAll = require('./methods/findAll')
 SBFRoot.prototype.get = require('./methods/get')
-SBFRoot.prototype.getAllIdentifiers = require('./methods/getAllIdentifiers')
 SBFRoot.prototype.getAdapter = require('./methods/getAdapter')
 SBFRoot.prototype.getTreeOptions = require('./methods/getTreeOptions')
 SBFRoot.prototype.remove = require('./methods/remove')

--- a/src/types/SBFRoot/SBFRoot.js
+++ b/src/types/SBFRoot/SBFRoot.js
@@ -25,6 +25,7 @@ class SBFRoot {
 SBFRoot.prototype.attachLeaf = require('./methods/attachLeaf')
 SBFRoot.prototype.find = require('./methods/find')
 SBFRoot.prototype.get = require('./methods/get')
+SBFRoot.prototype.getAllIdentifiers = require('./methods/getAllIdentifiers')
 SBFRoot.prototype.getAdapter = require('./methods/getAdapter')
 SBFRoot.prototype.getTreeOptions = require('./methods/getTreeOptions')
 SBFRoot.prototype.remove = require('./methods/remove')

--- a/src/types/SBFRoot/methods/find.js
+++ b/src/types/SBFRoot/methods/find.js
@@ -1,22 +1,34 @@
-async function find(key){
+async function findEquals(key){
   let leafIndex = 0;
   this.keys.forEach((_key)=>{
     if(key<=_key) return;
     leafIndex++;
   });
 
-  const leaf = this.childrens[leafIndex];
-  let result = await leaf.find(key);
+  let result = [];
 
-  if(leafIndex>0){
-    const left = this.childrens[leafIndex];
-    result = result.concat(result, await left.find(key));
-  }
+
+  const left = this.childrens[leafIndex];
+  result = result.concat(await left.find(key));
+
   // We also check the leaf nearby
   if(this.childrens.length>leafIndex+1){
     const right = this.childrens[leafIndex+1];
-    result = result.concat(result, await right.find(key));
+    result = result.concat(await right.find(key));
   }
   return result;
+}
+async function find(key, operator = '$eq'){
+  switch (operator) {
+    case '$eq':
+      return findEquals.call(this,key);
+      break;
+    case '$neq':
+      const findAllIdentifier = await this.findAll();
+      const excludedIdentifiers = await findEquals.call(this, key);
+      return findAllIdentifier.filter(id => !excludedIdentifiers.includes(id));
+    default:
+      throw new Error(`Not handled operator ${operator}`)
+  }
 }
 module.exports = find;

--- a/src/types/SBFRoot/methods/find.js
+++ b/src/types/SBFRoot/methods/find.js
@@ -1,32 +1,23 @@
-async function findEquals(key){
-  let leafIndex = 0;
-  this.keys.forEach((_key)=>{
-    if(key<=_key) return;
-    leafIndex++;
-  });
+const findEquals = require('./ops/findEquals');
+const findLowerThan = require('./ops/findLowerThan');
+const findGreaterThan = require('./ops/findGreaterThan');
 
-  let result = [];
-
-
-  const left = this.childrens[leafIndex];
-  result = result.concat(await left.find(key));
-
-  // We also check the leaf nearby
-  if(this.childrens.length>leafIndex+1){
-    const right = this.childrens[leafIndex+1];
-    result = result.concat(await right.find(key));
-  }
-  return result;
-}
 async function find(key, operator = '$eq'){
   switch (operator) {
     case '$eq':
       return findEquals.call(this,key);
-      break;
     case '$neq':
       const findAllIdentifier = await this.findAll();
       const excludedIdentifiers = await findEquals.call(this, key);
       return findAllIdentifier.filter(id => !excludedIdentifiers.includes(id));
+    case '$lte':
+      return findLowerThan.call(this, key, true);
+    case '$lt':
+      return findLowerThan.call(this, key, false);
+    case '$gt':
+      return findGreaterThan.call(this, key, false);
+    case '$gte':
+      return findGreaterThan.call(this, key, true);
     default:
       throw new Error(`Not handled operator ${operator}`)
   }

--- a/src/types/SBFRoot/methods/findAll.js
+++ b/src/types/SBFRoot/methods/findAll.js
@@ -1,0 +1,17 @@
+async function findAll(){
+  let result = [];
+
+  let p = [];
+  this.childrens.forEach((child)=>{
+    p.push(child.findAll());
+  });
+
+  await Promise.all(p).then((res)=>{
+    res.forEach((resolvedP)=>{
+      result = result.concat(resolvedP);
+    });
+  });
+
+  return result;
+}
+module.exports = findAll;

--- a/src/types/SBFRoot/methods/ops/findEquals.js
+++ b/src/types/SBFRoot/methods/ops/findEquals.js
@@ -1,0 +1,20 @@
+module.exports = async function findEquals(key){
+  let leafIndex = 0;
+  this.keys.forEach((_key)=>{
+    if(key<=_key) return;
+    leafIndex++;
+  });
+
+  let result = [];
+
+
+  const left = this.childrens[leafIndex];
+  result = result.concat(await left.find(key));
+
+  // We also check the leaf nearby
+  if(this.childrens.length>leafIndex+1){
+    const right = this.childrens[leafIndex+1];
+    result = result.concat(await right.find(key));
+  }
+  return result;
+};

--- a/src/types/SBFRoot/methods/ops/findGreaterThan.js
+++ b/src/types/SBFRoot/methods/ops/findGreaterThan.js
@@ -1,0 +1,39 @@
+async function findGreaterThan(key, includeKey=false){
+  let result = [];
+
+  // We first see where our key is located;
+  let leafIndex = 0;
+
+  this.keys.forEach((_key)=>{
+    if(key<=_key) return;
+    leafIndex++;
+  });
+
+
+
+  // first, we lookup for all greater than matches in the actual leaf where we had our el.
+  result = result.concat(await this.childrens[leafIndex].findGreaterThan(key, includeKey));
+  // If our key is in the keys, then right item will contains our key and it's superior elements
+  // We need this extra step first
+  let start = leafIndex+1;
+  let p = [];
+  if(this.keys.includes(key)){
+
+    p.push(this.childrens[start].findGreaterThan(key, includeKey));
+    start+=1;
+  }
+  // All bigger leaf that our leafIndex needs to be included
+  if(leafIndex<this.childrens.length-1){
+    this.childrens.slice(start).forEach((child, i)=>{
+      p.push(child.findAll());
+    });
+  }
+
+  await Promise.all(p).then((res)=>{
+    res.forEach((p)=>{
+      result = result.concat(p);
+    })
+  });
+  return result;
+};
+module.exports = findGreaterThan;

--- a/src/types/SBFRoot/methods/ops/findLowerThan.js
+++ b/src/types/SBFRoot/methods/ops/findLowerThan.js
@@ -19,7 +19,6 @@ async function findLowerThan(key, includeKey=false){
     });
 
     await Promise.all(p).then((res)=>{
-      console.log({res})
       res.forEach((p)=>{
         result = result.concat(p);
 

--- a/src/types/SBFRoot/methods/ops/findLowerThan.js
+++ b/src/types/SBFRoot/methods/ops/findLowerThan.js
@@ -1,0 +1,38 @@
+const {difference} = require('lodash');
+async function findLowerThan(key, includeKey=false){
+  let result = [];
+
+  // We first see where our key is located;
+  let leafIndex = 0;
+
+  this.keys.forEach((_key)=>{
+    if(key<=_key) return;
+    leafIndex++;
+  });
+  // All smaller leaf that our leafIndex needs to be included
+  if(leafIndex>=1){
+
+    let p = [];
+
+    this.childrens.slice(0, leafIndex).forEach((child)=>{
+      p.push(child.findAll());
+    });
+
+    await Promise.all(p).then((res)=>{
+      console.log({res})
+      res.forEach((p)=>{
+        result = result.concat(p);
+
+      })
+    });
+  }
+
+  // Finally, we lookup for all lower than matches in the actual leaf where we had our el.
+  result = result.concat(await this.childrens[leafIndex].findLowerThan(key, includeKey));
+
+  if(this.keys.includes(key)){
+    result = result.concat(await this.childrens[leafIndex+1].findLowerThan(key, includeKey));
+  }
+  return result;
+};
+module.exports = findLowerThan;

--- a/src/types/SBFTree/SBFTree.js
+++ b/src/types/SBFTree/SBFTree.js
@@ -35,7 +35,6 @@ class SBFTree {
 
 SBFTree.prototype.find = require('./methods/find');
 SBFTree.prototype.get = require('./methods/get');
-SBFTree.prototype.getAll = require('./methods/getAll');
 SBFTree.prototype.insert = require('./methods/insert');
 SBFTree.prototype.remove = require('./methods/remove');
 module.exports = SBFTree;

--- a/src/types/SBFTree/SBFTree.js
+++ b/src/types/SBFTree/SBFTree.js
@@ -35,6 +35,7 @@ class SBFTree {
 
 SBFTree.prototype.find = require('./methods/find');
 SBFTree.prototype.get = require('./methods/get');
+SBFTree.prototype.getAll = require('./methods/getAll');
 SBFTree.prototype.insert = require('./methods/insert');
 SBFTree.prototype.remove = require('./methods/remove');
 module.exports = SBFTree;

--- a/src/types/SBFTree/methods/find.js
+++ b/src/types/SBFTree/methods/find.js
@@ -1,3 +1,3 @@
-module.exports = async function find(key){
-  return this.root.find(key);
+module.exports = async function find(key, operator){
+  return this.root.find(key, operator);
 }

--- a/src/types/SBTree/ops/query.js
+++ b/src/types/SBTree/ops/query.js
@@ -61,7 +61,7 @@ async function query(query) {
 
         // TODO : Move to Promise.all. Expect changes, no point to not parallel the calls. We use this for now.
         for(let operator of operators){
-          const value = await fieldTree.find(queryFieldValue, operator);
+          const value = await fieldTree.find(queryFieldValue[operator], operator);
           if (value) {
             listOfFieldLookup = listOfFieldLookup.concat(value)
           } else {

--- a/src/types/SBTree/ops/query.js
+++ b/src/types/SBTree/ops/query.js
@@ -2,6 +2,27 @@ const {map, each, intersection} = require('lodash');
 
 const get = require('./get');
 
+const comparators = {
+  numeric: (keys) => {
+    let leafIndex = 0;
+    keys.forEach((_key) => {
+      if (key <= _key) return;
+      leafIndex++;
+    });
+    return leafIndex;
+  }
+}
+
+
+async function resolveDocuments(self, objectIds) {
+  const documents = [];
+  for (const oid of objectIds) {
+    const doc = await self.getDocument(oid);
+    documents.push(doc);
+  }
+  return documents;
+}
+
 async function query(query) {
   const self = this;
   let listOfFieldLookup = [];
@@ -11,28 +32,48 @@ async function query(query) {
     return [await get.call(this, _id)]
   }
 
-  for(const queryFieldName in query){
+  for (const queryFieldName in query) {
     const queryFieldValue = query[queryFieldName];
-    if (!this.getFieldTree(queryFieldName)) {
+    const fieldTree = this.getFieldTree(queryFieldName);
+    if (!fieldTree) {
       continue;
-      // throw new Error(`No field ${queryFieldName} found`)
     }
-    const value = await this.getFieldTree(queryFieldName).find(queryFieldValue);
-    if (value) {
-      listOfFieldLookup = listOfFieldLookup.concat(value)
-    } else {
-      throw new Error(`No value ${queryFieldName} found : ${value}, ${query}`)
+
+    // At this point, query can still be either strict or diverse. Let's sort this out
+    const queryFieldValueType = typeof queryFieldValue;
+
+    const keys = [];
+
+
+    // We try to look up the easy cases, strict equality
+    if(['string', 'number'].includes(typeof queryFieldValue)){
+      let operator = '$eq';
+      const value = await fieldTree.find(queryFieldValue, operator);
+      if (value) {
+        listOfFieldLookup = listOfFieldLookup.concat(value)
+      } else {
+        throw new Error(`No value ${queryFieldName} found : ${value}, query(${JSON.stringify(query)})`)
+      }
+    }else{
+      if(Array.isArray(queryFieldValue)) throw new Error(`Not supported array input. Please open a Github issue to specify your need.`);
+      if(typeof queryFieldValue === "object" && !Array.isArray(queryFieldValue)){
+        const operators = Object.keys(queryFieldValue).filter((el)=>  el[0]==='$');
+
+        // TODO : Move to Promise.all. Expect changes, no point to not parallel the calls. We use this for now.
+        for(let operator of operators){
+          const value = await fieldTree.find(queryFieldValue, operator);
+          if (value) {
+            listOfFieldLookup = listOfFieldLookup.concat(value)
+          } else {
+            throw new Error(`No value ${queryFieldName} found : ${value}, query(${JSON.stringify(query)})`)
+          }
+        }
+      }
     }
   }
 
   const matchingObjectIds = intersection(listOfFieldLookup);
-  const documents = [];
-
-  for(const oid of matchingObjectIds){
-    const doc = await self.getDocument(oid);
-    documents.push(doc);
-  }
-
+  const documents = await resolveDocuments(self, matchingObjectIds);
   return documents;
 };
 module.exports = query;

--- a/src/types/SBTree/ops/query.js
+++ b/src/types/SBTree/ops/query.js
@@ -26,7 +26,7 @@ async function resolveDocuments(self, objectIds) {
 async function query(query) {
   const self = this;
   let listOfFieldLookup = [];
-
+  if(query===undefined) return [];
   if (query._id && Object.keys(query).length === 1) {
     const {_id} = query;
     return [await get.call(this, _id)]

--- a/test/benchmark/benchmark.js
+++ b/test/benchmark/benchmark.js
@@ -56,7 +56,13 @@ describe('SBTree - Performance - Benchmark within test ', async function () {
         const rand = Math.floor(Math.random() * (findData.length - 1 + 1) + 0);
         const data = findData.splice(rand, 1)[0];
         return tree.findDocuments(data)
-      }]
+      }],
+      // ['negFindOp', async () => {
+        // const rand = Math.floor(Math.random() * (findData.length - 1 + 1) + 0);
+        // const data = findData.splice(rand, 1)[0];
+        // console.log(data)
+        // return tree.findDocuments(data)
+      // }]
     ];
 
     const processNext = async (jobFn, jobName) => {

--- a/test/types/SBFRoot/methods/find.js
+++ b/test/types/SBFRoot/methods/find.js
@@ -1,0 +1,91 @@
+const {expect} = require('chai');
+const SFBLeaf = require('../../../../src/types/SBFLeaf/SBFLeaf');
+const MemoryAdapter = require('../../../../src/adapters/MemoryAdapter/MemoryAdapter');
+const find = require('../../../../src/types/SBFRoot/methods/find');
+const fixtures = {
+  documents: {
+    // '5d6ebb7e21f1df6ff7482631': {
+    //   "age": 33,
+    //   "name": "Devan",
+    //   "email": "Devan@Prohaska.com",
+    //   "address":{
+    //     "country":'Russia'
+    //   },
+    //   "_id": "5d6ebb7e21f1df6ff7482631"
+    // },
+    '5d6ebb7e21f1df6ff7482631':{
+      "age": 33,
+      "name": "Devan",
+      "_id": "5d6ebb7e21f1df6ff7482631"
+    },
+    '5d6ebb7e21f1df6ff7482621':{
+      "age": 17,
+      "name": "Silvio",
+      "_id": "5d6ebb7e21f1df6ff7482621"
+    },
+    "5d6ebb7e21f1df6ff7482641":{
+      "age": 45,
+      "name": "Patricia",
+      "_id": "5d6ebb7e21f1df6ff7482641"
+    }
+  }
+};
+
+const calledFn = [];
+
+const adapter = new MemoryAdapter();
+adapter.documents = {
+  '5d6ebb7e21f1df6ff7482631': {_id: '5d6ebb7e21f1df6ff7482631', age: 33},
+  '5d6ebb7e21f1df6ff7482621': {_id: '5d6ebb7e21f1df6ff7482621', age: 17},
+  '5d6ebb7e21f1df6ff7482641': {_id: '5d6ebb7e21f1df6ff7482641', age: 45}
+};
+adapter.addInLeaf('16d075318572b', 'age', '5d6ebb7e21f1df6ff7482621', 17)
+adapter.addInLeaf('16d07531858f6', 'age', '5d6ebb7e21f1df6ff7482631', 33)
+adapter.addInLeaf('16d07531858f6', 'age', '5d6ebb7e21f1df6ff7482641', 45)
+const fakeAgeTreeParent = {
+  field:'age',
+  getAdapter:()=> adapter,
+  find:(key)=>{
+    console.log('findkey',key)
+  },
+
+};
+const fakeSelf = {
+  keys:[33],
+  childrens:[
+      new SFBLeaf({ name: '16d075318572b', type: 'leaf' , parent:fakeAgeTreeParent}),
+      new SFBLeaf({ name: '16d07531858f6', type: 'leaf' , parent:fakeAgeTreeParent}),
+  ],
+};
+fakeSelf.findAll = require('../../../../src/types/SBFRoot/methods/findAll').bind(fakeSelf);
+
+describe('SBFTree - methods - find', () => {
+  //FIXME : It is too strict for string. jean should be found when we request Jean.
+  it('should find using strict operator', async function () {
+    const res = await find.call(fakeSelf, 33);
+    const resEqOp = await find.call(fakeSelf, 33, '$eq');
+
+    expect(res).to.deep.equal(resEqOp);
+    expect(await find.call(fakeSelf, 32)).to.deep.equal([]);
+    expect(await find.call(fakeSelf, 17)).to.deep.equal(['5d6ebb7e21f1df6ff7482621']);
+    expect(await find.call(fakeSelf, 45)).to.deep.equal(['5d6ebb7e21f1df6ff7482641']);
+  });
+  it('should find using negated equality operation', async function () {
+    const res = await find.call(fakeSelf, 33, '$neq');
+    expect(res).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482621', '5d6ebb7e21f1df6ff7482641' ])
+  });
+  // it('should detect strict operators', async function () {
+  //   const res = await query.call(fakeSelf, {age: 33});
+  //   expect(calledFn[0]).to.deep.equal(['age','find',33, '$eq']);
+  // });
+  // it('should detect other operators', async function () {
+  //   const res2 = await query.call(fakeSelf, {age: {$gte:33, $lte:50}});
+  //   expect(calledFn[1]).to.deep.equal(['age','find',33, '$gte']);
+  //   expect(calledFn[2]).to.deep.equal(['age','find',50, '$lte']);
+  // });
+  // it('should detect nested object', async function () {
+  //   //TODO
+  //   // const res3 = await query.call(fakeSelf, {address: {country:{$in:['France', 'Russia']}}});
+  //
+  // });
+});

--- a/test/types/SBFRoot/methods/find.js
+++ b/test/types/SBFRoot/methods/find.js
@@ -64,8 +64,8 @@ describe('SBFTree - methods - find', () => {
   it('should find using strict operator', async function () {
     const res = await find.call(fakeSelf, 33);
     const resEqOp = await find.call(fakeSelf, 33, '$eq');
-
     expect(res).to.deep.equal(resEqOp);
+    expect(res).to.deep.equal(['5d6ebb7e21f1df6ff7482631']);
     expect(await find.call(fakeSelf, 32)).to.deep.equal([]);
     expect(await find.call(fakeSelf, 17)).to.deep.equal(['5d6ebb7e21f1df6ff7482621']);
     expect(await find.call(fakeSelf, 45)).to.deep.equal(['5d6ebb7e21f1df6ff7482641']);
@@ -74,15 +74,70 @@ describe('SBFTree - methods - find', () => {
     const res = await find.call(fakeSelf, 33, '$neq');
     expect(res).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482621', '5d6ebb7e21f1df6ff7482641' ])
   });
-  // it('should detect strict operators', async function () {
-  //   const res = await query.call(fakeSelf, {age: 33});
-  //   expect(calledFn[0]).to.deep.equal(['age','find',33, '$eq']);
-  // });
-  // it('should detect other operators', async function () {
-  //   const res2 = await query.call(fakeSelf, {age: {$gte:33, $lte:50}});
-  //   expect(calledFn[1]).to.deep.equal(['age','find',33, '$gte']);
-  //   expect(calledFn[2]).to.deep.equal(['age','find',50, '$lte']);
-  // });
+  it('should find using lower than operators', async function () {
+    const res = await find.call(fakeSelf, 1, '$lt');
+    expect(res).to.be.deep.equal([ ])
+    const res2 = await find.call(fakeSelf, 100, '$lt');
+    expect(res2).to.be.deep.equal(['5d6ebb7e21f1df6ff7482621','5d6ebb7e21f1df6ff7482631','5d6ebb7e21f1df6ff7482641' ])
+    const res3 = await find.call(fakeSelf, 33, '$lt');
+    expect(res3).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482621' ])
+    const res4 = await find.call(fakeSelf, 34, '$lt');
+    expect(res4).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482621', '5d6ebb7e21f1df6ff7482631' ])
+  });
+  it('should find using lower than or equal operators', async function () {
+    const res = await find.call(fakeSelf, 1, '$lte');
+    expect(res).to.be.deep.equal([ ])
+    const res2 = await find.call(fakeSelf, 100, '$lte');
+    expect(res2).to.be.deep.equal(['5d6ebb7e21f1df6ff7482621','5d6ebb7e21f1df6ff7482631','5d6ebb7e21f1df6ff7482641' ])
+    const res3 = await find.call(fakeSelf, 17, '$lte');
+    expect(res3).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482621'])
+    const res4 = await find.call(fakeSelf, 34, '$lte');
+    expect(res4).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482621', '5d6ebb7e21f1df6ff7482631' ])
+
+    const res5 = await find.call(fakeSelf, 33, '$lte');
+    expect(res5).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482621', '5d6ebb7e21f1df6ff7482631' ])
+  });
+  it('should find using greater than operators', async function (){
+    const res = await find.call(fakeSelf, 1, '$gt');
+    expect(res).to.be.deep.equal(['5d6ebb7e21f1df6ff7482621','5d6ebb7e21f1df6ff7482631','5d6ebb7e21f1df6ff7482641' ])
+    const res2 = await find.call(fakeSelf, 100, '$gt');
+    expect(res2).to.be.deep.equal([ ])
+    const res3 = await find.call(fakeSelf, 16, '$gt');
+    expect(res3).to.be.deep.equal(['5d6ebb7e21f1df6ff7482621','5d6ebb7e21f1df6ff7482631','5d6ebb7e21f1df6ff7482641' ])
+    const res4 = await find.call(fakeSelf, 17, '$gt');
+    expect(res4).to.be.deep.equal(['5d6ebb7e21f1df6ff7482631','5d6ebb7e21f1df6ff7482641' ])
+    const res5 = await find.call(fakeSelf, 32, '$gt');
+    expect(res5).to.be.deep.equal(['5d6ebb7e21f1df6ff7482631', '5d6ebb7e21f1df6ff7482641' ])
+    const res6 = await find.call(fakeSelf, 33, '$gt');
+    expect(res6).to.be.deep.equal([  '5d6ebb7e21f1df6ff7482641' ])
+    const res7 = await find.call(fakeSelf, 44, '$gt');
+    expect(res7).to.be.deep.equal([  '5d6ebb7e21f1df6ff7482641' ])
+    const res8 = await find.call(fakeSelf, 45, '$gt');
+    expect(res8).to.be.deep.equal([   ])
+  });
+  it('should find using greater than or equal operators', async function (){
+    const res = await find.call(fakeSelf, 1, '$gte');
+    expect(res).to.be.deep.equal(['5d6ebb7e21f1df6ff7482621','5d6ebb7e21f1df6ff7482631','5d6ebb7e21f1df6ff7482641' ])
+    const res2 = await find.call(fakeSelf, 100, '$gte');
+    expect(res2).to.be.deep.equal([ ])
+    const res3 = await find.call(fakeSelf, 16, '$gte');
+    expect(res3).to.be.deep.equal(['5d6ebb7e21f1df6ff7482621','5d6ebb7e21f1df6ff7482631','5d6ebb7e21f1df6ff7482641' ])
+    const res4 = await find.call(fakeSelf, 17, '$gte');
+    expect(res4).to.be.deep.equal(['5d6ebb7e21f1df6ff7482621','5d6ebb7e21f1df6ff7482631','5d6ebb7e21f1df6ff7482641' ])
+    const res5 = await find.call(fakeSelf, 32, '$gte');
+    expect(res5).to.be.deep.equal(['5d6ebb7e21f1df6ff7482631', '5d6ebb7e21f1df6ff7482641' ])
+    const res6 = await find.call(fakeSelf, 33, '$gte');
+    expect(res6).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482631', '5d6ebb7e21f1df6ff7482641' ])
+    const res7 = await find.call(fakeSelf, 44, '$gte');
+    expect(res7).to.be.deep.equal([  '5d6ebb7e21f1df6ff7482641' ])
+    const res8 = await find.call(fakeSelf, 45, '$gte');
+    expect(res8).to.be.deep.equal([ '5d6ebb7e21f1df6ff7482641'  ])
+    const res9 = await find.call(fakeSelf, 46, '$gte');
+    expect(res9).to.be.deep.equal([   ])
+
+  });
+
+
   // it('should detect nested object', async function () {
   //   //TODO
   //   // const res3 = await query.call(fakeSelf, {address: {country:{$in:['France', 'Russia']}}});

--- a/test/types/SBFRoot/methods/findAll.js
+++ b/test/types/SBFRoot/methods/findAll.js
@@ -1,0 +1,67 @@
+const {expect} = require('chai');
+const SFBLeaf = require('../../../../src/types/SBFLeaf/SBFLeaf');
+const MemoryAdapter = require('../../../../src/adapters/MemoryAdapter/MemoryAdapter');
+const findAll = require('../../../../src/types/SBFRoot/methods/findAll');
+const fixtures = {
+  documents: {
+    // '5d6ebb7e21f1df6ff7482631': {
+    //   "age": 33,
+    //   "name": "Devan",
+    //   "email": "Devan@Prohaska.com",
+    //   "address":{
+    //     "country":'Russia'
+    //   },
+    //   "_id": "5d6ebb7e21f1df6ff7482631"
+    // },
+    '5d6ebb7e21f1df6ff7482631':{
+      "age": 33,
+      "name": "Devan",
+      "_id": "5d6ebb7e21f1df6ff7482631"
+    },
+    '5d6ebb7e21f1df6ff7482621':{
+      "age": 17,
+      "name": "Silvio",
+      "_id": "5d6ebb7e21f1df6ff7482621"
+    },
+    "5d6ebb7e21f1df6ff7482641":{
+      "age": 45,
+      "name": "Patricia",
+      "_id": "5d6ebb7e21f1df6ff7482641"
+    }
+  }
+};
+
+const calledFn = [];
+
+const adapter = new MemoryAdapter();
+adapter.documents = {
+  '5d6ebb7e21f1df6ff7482621': {_id: '5d6ebb7e21f1df6ff7482621', age: 17},
+  '5d6ebb7e21f1df6ff7482631': {_id: '5d6ebb7e21f1df6ff7482631', age: 33},
+  '5d6ebb7e21f1df6ff7482641': {_id: '5d6ebb7e21f1df6ff7482641', age: 45}
+};
+adapter.addInLeaf('16d075318572b', 'age', '5d6ebb7e21f1df6ff7482621', 17)
+adapter.addInLeaf('16d07531858f6', 'age', '5d6ebb7e21f1df6ff7482631', 33)
+adapter.addInLeaf('16d07531858f6', 'age', '5d6ebb7e21f1df6ff7482641', 45)
+const fakeAgeTreeParent = {
+  field:'age',
+  getAdapter:()=> adapter,
+  find:(key)=>{
+    console.log('findkey',key)
+  },
+
+};
+const fakeSelf = {
+  keys:[33],
+  childrens:[
+    new SFBLeaf({ name: '16d075318572b', type: 'leaf' , parent:fakeAgeTreeParent}),
+    new SFBLeaf({ name: '16d07531858f6', type: 'leaf' , parent:fakeAgeTreeParent}),
+  ],
+};
+fakeSelf.getAllIdentifiers = require('../../../../src/types/SBFRoot/methods/getAllIdentifiers').bind(fakeSelf);
+
+describe('SBFTree - methods - findAll', () => {
+  it('should find all identifiers', async function () {
+    const res = await findAll.call(fakeSelf);
+    expect(res).to.deep.equal(Object.keys(adapter.documents));
+  });
+});

--- a/test/types/SBFRoot/methods/findAll.js
+++ b/test/types/SBFRoot/methods/findAll.js
@@ -57,7 +57,6 @@ const fakeSelf = {
     new SFBLeaf({ name: '16d07531858f6', type: 'leaf' , parent:fakeAgeTreeParent}),
   ],
 };
-fakeSelf.getAllIdentifiers = require('../../../../src/types/SBFRoot/methods/getAllIdentifiers').bind(fakeSelf);
 
 describe('SBFTree - methods - findAll', () => {
   it('should find all identifiers', async function () {

--- a/test/types/SBTree/ops/query.js
+++ b/test/types/SBTree/ops/query.js
@@ -1,17 +1,15 @@
 const {expect} = require('chai');
 const query = require('../../../../src/types/SBTree/ops/query');
 
-// await col.insert({
-//   "name": "Devan",
-//   "email": "Devan@Prohaska.com",
-//   "_id": "5d6ebb7e21f1df6ff7482631"
-// });
 const fixtures = {
   documents: {
     '5d6ebb7e21f1df6ff7482631': {
       "age": 33,
       "name": "Devan",
       "email": "Devan@Prohaska.com",
+      "address":{
+        "country":'Russia'
+      },
       "_id": "5d6ebb7e21f1df6ff7482631"
     }
   }
@@ -32,11 +30,18 @@ const fakeSelf = {
 };
 
 describe('SBTree - ops - query', () => {
-  it('should detect strict comparators', async function () {
+  it('should detect strict operators', async function () {
     const res = await query.call(fakeSelf, {age: 33});
     expect(calledFn[0]).to.deep.equal(['age','find',33, '$eq']);
-    // const res2 = await query.call(fakeSelf, {age: {$gte:33, $lte:50}});
-    // conso
-    // expect(calledFn[1]).to.deep.equal(['age','find',33, '$eq']);
+  });
+  it('should detect other operators', async function () {
+    const res2 = await query.call(fakeSelf, {age: {$gte:33, $lte:50}});
+    expect(calledFn[1]).to.deep.equal(['age','find',33, '$gte']);
+    expect(calledFn[2]).to.deep.equal(['age','find',50, '$lte']);
+  });
+  it('should detect nested object', async function () {
+    //TODO
+    // const res3 = await query.call(fakeSelf, {address: {country:{$in:['France', 'Russia']}}});
+
   });
 });

--- a/test/types/SBTree/ops/query.js
+++ b/test/types/SBTree/ops/query.js
@@ -1,0 +1,42 @@
+const {expect} = require('chai');
+const query = require('../../../../src/types/SBTree/ops/query');
+
+// await col.insert({
+//   "name": "Devan",
+//   "email": "Devan@Prohaska.com",
+//   "_id": "5d6ebb7e21f1df6ff7482631"
+// });
+const fixtures = {
+  documents: {
+    '5d6ebb7e21f1df6ff7482631': {
+      "age": 33,
+      "name": "Devan",
+      "email": "Devan@Prohaska.com",
+      "_id": "5d6ebb7e21f1df6ff7482631"
+    }
+  }
+};
+
+const calledFn = [];
+
+const fakeSelf = {
+  getDocument: (docId) => fixtures.documents[docId],
+  getFieldTree: (fieldName) => {
+    return {
+      find: (key, operator) => {
+        calledFn.push([fieldName, 'find', key, operator]);
+        return ['5d6ebb7e21f1df6ff7482631']
+      }
+    }
+  }
+};
+
+describe('SBTree - ops - query', () => {
+  it('should detect strict comparators', async function () {
+    const res = await query.call(fakeSelf, {age: 33});
+    expect(calledFn[0]).to.deep.equal(['age','find',33, '$eq']);
+    // const res2 = await query.call(fakeSelf, {age: {$gte:33, $lte:50}});
+    // conso
+    // expect(calledFn[1]).to.deep.equal(['age','find',33, '$eq']);
+  });
+});


### PR DESCRIPTION
### Issue being fixed or implemented  

Right now, we are only able to perform strict comparison with our find method. 
We need to be able to findAll, and find with specific operators. 

### What was done  
- $eq operator
- $neq operator
- $lt, lte, gt, gte operators
- findAll() as a method that will returns all identifiers in a list. 

### Notes  

We did not decide to just sequentially add our elements starting from our match. But it might would have been a good solution. 
Let us put that in our mind as a potential improvement later on.

### Reviewer notes : 
Extra care needed on internode leaf, as our test only covers an order or 3 with 3 data. Improvement needed there too. 