### PR TITLE
fix(FsAdapter): readiness 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## 2.0.1 (2019-10-08)
+
+- https://github.com/Alex-Werner/SBTree/pull/5
+
+## 2.0.0 (2019-10-08)
+
+- https://github.com/Alex-Werner/SBTree/pull/4
+
 ## 1.3.0 (2019-09-)
 ## 1.2.1 (2019-09-07)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtree",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtree",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Optimised document store using B+ Tree for fields. Adapters support for In-Memory and FileSystem",
   "main": "index.js",
   "scripts": {

--- a/src/adapters/FsAdapter/methods/getDocument.js
+++ b/src/adapters/FsAdapter/methods/getDocument.js
@@ -1,3 +1,3 @@
 module.exports = async function getDocument(identifier){
-  return JSON.parse(JSON.stringify(this.openDocument(identifier)));
+  return JSON.parse(JSON.stringify(await this.openDocument(identifier)));
 }

--- a/src/adapters/FsAdapter/methods/openDocument.js
+++ b/src/adapters/FsAdapter/methods/openDocument.js
@@ -1,5 +1,5 @@
 module.exports = async function openDocument(identifer) {
-  const job = await this.queue.add('File.read', `${this.options.path}/d/${identifer}.dat`);
+  const job = await this.queue.add('File.read', `${this.path}/d/${identifer}.dat`);
   await job.execution();
   let data = {}
   if (job.results.constructor.name !== Error.name) {

--- a/src/adapters/FsAdapter/methods/updateDocument.js
+++ b/src/adapters/FsAdapter/methods/updateDocument.js
@@ -1,5 +1,5 @@
 module.exports = async function updateDocument(_doc){
-    const job = await this.queue.add('File.appendJSON', `${this.options.path}/d/${_doc._id}.dat`, _doc);
+    const job = await this.queue.add('File.appendJSON', `${this.path}/d/${_doc._id}.dat`, _doc);
     await job.execution();
     let data = {}
     if (job.results.constructor.name !== Error.name) {

--- a/src/types/SBFRoot/methods/ops/findEquals.js
+++ b/src/types/SBFRoot/methods/ops/findEquals.js
@@ -28,8 +28,10 @@ module.exports = async function findEquals(value){
     await Promise.all(p).then((res)=>{
       if(res.length>0){
         res.forEach((_pRes)=>{
-          result.identifiers.push(..._pRes.identifiers);
-          result.keys.push(..._pRes.keys);
+          if(_pRes.identifiers){
+            result.identifiers.push(..._pRes.identifiers);
+            result.keys.push(..._pRes.keys);
+          }
         })
       }
     });

--- a/src/types/SBTree/methods/deleteDocuments.js
+++ b/src/types/SBTree/methods/deleteDocuments.js
@@ -1,9 +1,13 @@
 const remove = require('../ops/remove');
+const {waitFor} = require('../../../utils/fn');
 
 async function deleteDocuments(query){
   if(!query || query === {}){
     // this would cause to delete all as we would query all.
     throw new Error('Invalid query')
+  }
+  if(!this.isReady){
+    await waitFor(this, 'isReady');
   }
 
   return (await remove.call(this,query));

--- a/src/types/SBTree/methods/findDocuments.js
+++ b/src/types/SBTree/methods/findDocuments.js
@@ -1,6 +1,10 @@
 const query = require('../ops/query');
+const {waitFor} = require('../../../utils/fn');
 
 async function findDocuments(params){
+  if(!this.isReady){
+    await waitFor(this, 'isReady');
+  }
   return (await query.call(this,params));
 
 };

--- a/src/utils/fn.js
+++ b/src/utils/fn.js
@@ -1,19 +1,16 @@
 const waitFor = async (watchedObject, watchedProp, successCallback) => {
+  if(watchedObject && watchedObject[watchedProp]) return true;
   return new Promise( (resolve, reject) => {
     let int = null;
     const resolver = () => {
-      console.log('exec')
-
       if (watchedObject[watchedProp]) {
         if(successCallback){
           successCallback();
         }
-        console.log('clear')
         int = clearInterval(int);
         return resolve(true)
       }
     };
-    console.log('set')
     int = setInterval(resolver, 20)
     setTimeout(resolver, 10000);
   });


### PR DESCRIPTION
### Issue being fixed or implemented  

With 2.0.0, FsAdapter wasn't able to open a document.

### What was done  

- Fix the removed `options` param on update and open
- Also added readiness listener on find and delete
- Correctly await when getting a document before trying to stringify.
- Impr : `fn.waitFor` should now be faster for 99.99% of the case on usage with FsAdapter.

### How Has This Been Tested?

Using a real use case, trying to store simple one field documents + expectation on the automated unit tests.

### Notes  

Result from the benchmark as ran by travis :

```
 SBTree - Performance - Standard Benchmark within test 
Will process 5000 elements
Finished writeOp in 137.000392 ms [36496.24593774885] ops
Finished getOp in 49.729244 ms [100544.46031795698] ops
Finished findOp in 90.294401 ms [55374.41906281653] ops
    ✓ should be fast (291ms)
======== SBTree 2.0.1 - Benchmark from mocha
= Write : 36496.24593774885 op/s [5000]
= Get : 100544.46031795698 op/s [5000]
= Find : 55374.41906281653 op/s [5000]
= ======== Summary
= Total : 15000 operations
= Duration : 0.277024037 s
= Avg : 64138.37510617412 op/s
    ✓ should display result
  SBTree - Performance - Extended Benchmark within test 
Will process 5000 elements
Finished writeOp in 91.816031 ms [54456.72117976871] ops
Finished negFindOp in 17812.63259 ms [53.33293634166852] ops
Finished gtFindOp in 13789.216144 ms [141.4148548863301] ops
Finished gteFindOp in 14332.176145 ms [132.56884235705155] ops
Finished ltFindOp in 13003.13552 ms [138.42815044351704] ops
Finished lteFindOp in 13970.069843 ms [136.00504659982323] ops
Finished inFindOp in 1116.791901 ms [1491.772995943315] ops
Finished ninFindOp in 35105.183682 ms [37.971600207962695] ops
    ✓ should be fast (109250ms)
======== SBTree 2.0.1 - Extended
= $ne : 53.33293634166852 op/s [950]
= $gt : 141.4148548863301 op/s [1950]
= $gte : 132.56884235705155 op/s [1900]
= $lt : 138.42815044351704 op/s [1800]
= $lte : 136.00504659982323 op/s [1900]
= $in : 1491.772995943315 op/s [1666]
= $nin : 37.971600207962695 op/s [1333]
= ======== Summary
= Total : 16499 operations
= Duration : 109.22102185600001 s
= Avg : 151.06066322793367 op/s
    ✓ should display result
  SBTree - Performance - Multi-Trees (index/field) benchmark within test 
Will process 10000 elements
Finished writeOp in 639.062708 ms [15647.91666735778] ops
Finished getOp in 124.217374 ms [80504.03641603306] ops
Finished findOp in 6033.727097 ms [1657.350397065862] ops
    ✓ should be fast (6869ms)
======== SBTree 2.0.1 - Multi-tree Benchmark from mocha
= Write : 15647.91666735778 op/s [10000]
= Get : 80504.03641603306 op/s [10000]
= Find : 1657.350397065862 op/s [10000]
= Total : 30000 operations
= Duration : 6.7970071789999995 s
= Avg : 32603.101160152237 op/s
```