### PR TITLE
feat: added extra basic nested object support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,17 @@
-## 2.0.1 (2019-10-08)
+## 2.1.0 (2019-10-08)
+https://github.com/Alex-Werner/SBTree/pull/6
 
-- https://github.com/Alex-Werner/SBTree/pull/5
+- feat: added basic nested object support
+
+## 2.0.1 (2019-10-08)
+https://github.com/Alex-Werner/SBTree/pull/5
+
+- fix: FsAdapter support for 2.0.0
 
 ## 2.0.0 (2019-10-08)
+https://github.com/Alex-Werner/SBTree/pull/4
 
-- https://github.com/Alex-Werner/SBTree/pull/4
+- feat: added remove documents supports
 
 ## 1.3.0 (2019-09-)
 ## 1.2.1 (2019-09-07)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtree",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtree",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Optimised document store using B+ Tree for fields. Adapters support for In-Memory and FileSystem",
   "main": "index.js",
   "scripts": {

--- a/src/adapters/MemoryAdapter/methods/getDocument.js
+++ b/src/adapters/MemoryAdapter/methods/getDocument.js
@@ -1,3 +1,7 @@
 module.exports = async function getDocument(identifier){
-  return JSON.parse(JSON.stringify(this.documents[identifier]));
-}
+  const doc = this.documents[identifier];
+  if(doc){
+    return JSON.parse(JSON.stringify(this.documents[identifier]));
+  }
+  return {_id:identifier};
+};

--- a/src/types/SBFNode/methods/remove.js
+++ b/src/types/SBFNode/methods/remove.js
@@ -8,7 +8,9 @@ async function remove(remCmd){
   });
 
   const leaf = this.childrens[leafIndex];
-  await leaf.remove(remCmd);
+  if(leaf){
+    await leaf.remove(remCmd);
+  }
 };
 module.exports = remove;
 

--- a/src/types/SBFRoot/methods/getAll.js
+++ b/src/types/SBFRoot/methods/getAll.js
@@ -11,8 +11,17 @@ async function getAll() {
         .all(p)
         .then((res) => {
           res.forEach((resolvedP) => {
-            result.identifiers.push(...resolvedP.identifiers);
-            result.keys.push(...resolvedP.keys);
+            if(resolvedP.identifiers){
+              result.identifiers.push(...resolvedP.identifiers);
+              result.keys.push(...resolvedP.keys);
+            }else if(Array.isArray(resolvedP)){
+              resolvedP.forEach((item) => {
+                result.identifiers.push(...item.identifiers);
+                result.keys.push(...item.keys);
+              });
+            }else{
+              throw new Error(`Unexpected type of resolvedP - type : ${typeof resolvedP}`)
+            }
           });
           resolve(result);
         });

--- a/src/types/SBFRoot/methods/remove.js
+++ b/src/types/SBFRoot/methods/remove.js
@@ -8,11 +8,13 @@ async function remove(remCmd){
   });
 
   const leaf = this.childrens[leafIndex];
-  await leaf.remove(remCmd);
+  if(leaf){
+    await leaf.remove(remCmd);
 
-  // This has been added for the case where previous also contains the same value
-  if(this.childrens[leafIndex-1]){
-    await this.childrens[leafIndex-1].remove(remCmd);
+    // This has been added for the case where previous also contains the same value
+    if(this.childrens[leafIndex-1]){
+      await this.childrens[leafIndex-1].remove(remCmd);
+    }
   }
 };
 module.exports = remove;

--- a/src/types/SBTree/ops/insert.js
+++ b/src/types/SBTree/ops/insert.js
@@ -11,15 +11,22 @@ async function insert(document) {
   const id = document._id.toString();
 
   for (const _fieldName in document) {
-    const _fieldValue = document[_fieldName]
-    if (_fieldName !== '_id') {
-      if (!this.getFieldTree(_fieldName)) {
-        this.setFieldTree({fieldName:_fieldName});
+    const _fieldValue = document[_fieldName];
+
+    const _fieldType = typeof _fieldValue;
+
+    if (['string','number'].includes(_fieldType)) {
+      if(_fieldName !== '_id'){
+        if (!this.getFieldTree(_fieldName)) {
+          this.setFieldTree({fieldName:_fieldName});
+        }
+        const fieldTree = this.getFieldTree(_fieldName);
+        if(fieldTree){
+          await fieldTree.insert(id, _fieldValue);
+        }
       }
-      const fieldTree = this.getFieldTree(_fieldName);
-      if(fieldTree){
-        await fieldTree.insert(id, _fieldValue);
-      }
+    }else{
+      this.verbose && console.log(`No index for ${_fieldName} : Typeof ${_fieldType} : ${JSON.stringify(_fieldValue)}`)
     }
   }
   await this.adapter.saveDocument(document);

--- a/test/e2e/use.case.2.js
+++ b/test/e2e/use.case.2.js
@@ -1,0 +1,24 @@
+const {expect} = require('chai');
+const {SBTree} = require('../..');
+const {draw}= require('../../src/utils/ascii');
+describe('E2E - Classic UseCase', function suite() {
+  describe('RegUser DB', () => {
+    const shiftedUsers = [];
+    const tree = new SBTree();
+    const customTree = new SBTree({
+      order: 3,
+    });
+
+    it('should allow to insert documents with basic nested support', async function () {
+      const doc = {
+        name:"Alex",
+        infos:{
+          job:{
+            sector: "IT"
+          }
+        }
+      };
+      await customTree.insertDocuments(doc);
+    });
+  });
+})

--- a/test/e2e/use.case.2.js
+++ b/test/e2e/use.case.2.js
@@ -1,24 +1,30 @@
 const {expect} = require('chai');
 const {SBTree} = require('../..');
-const {draw}= require('../../src/utils/ascii');
 describe('E2E - Classic UseCase', function suite() {
   describe('RegUser DB', () => {
-    const shiftedUsers = [];
-    const tree = new SBTree();
     const customTree = new SBTree({
       order: 3,
     });
-
-    it('should allow to insert documents with basic nested support', async function () {
-      const doc = {
-        name:"Alex",
-        infos:{
-          job:{
-            sector: "IT"
-          }
+    const alex = {
+      _id: "5d9d74a2668f032206e4dc01",
+      name:"Alex",
+      infos:{
+        job:{
+          sector: "IT"
         }
-      };
-      await customTree.insertDocuments(doc);
+      }
+    };
+    it('should allow to insert documents with basic nested support', async function () {
+      await customTree.insertDocuments(alex);
+    });
+    it('should allow to find the document', async function () {
+      const doc = await customTree.findDocuments({name:"Alex"});
+      expect(doc).to.deep.equal([alex])
+    });
+    it('should not be able to find document on nested',async function () {
+      // May be we should warn user in some way ?
+      const doc = await customTree.findDocuments({infos:{job:{sector:"IT"}}});
+      expect(doc).to.deep.equal([]);
     });
   });
 })

--- a/test/unit/types/SBTree/ops/insert.js
+++ b/test/unit/types/SBTree/ops/insert.js
@@ -51,10 +51,7 @@ describe('SBTree - ops - insert', () => {
       ['setFieldTree', 'email'],
       ['getFieldTree', 'email'],
 
-      ['getFieldTree', 'address'],
-      ['setFieldTree', 'address'],
-      ['getFieldTree', 'address'],
-
+      // Address is not called as we discard it (type is object)
       ['savedDocument', '5d6ebb7e21f1df6ff7482631'],
     ]);
   });

--- a/test/z_benchmark/1.standard.js
+++ b/test/z_benchmark/1.standard.js
@@ -68,7 +68,7 @@ describe('SBTree - Performance - Standard Benchmark within test ', async functio
         const len = findData.length;
         if (len > 0) {
           const rand = Math.floor(Math.random() * (findData.length - 1 + 1) + 0);
-          const query = {age: findData.splice(rand, 1)[0].age};
+          const query = findData.splice(rand, 1)[0];
           return tree.findDocuments(query)
         }
       }],

--- a/test/z_benchmark/1.standard.js
+++ b/test/z_benchmark/1.standard.js
@@ -24,6 +24,12 @@ let standard = {
     executedOp: 0,
     duration: 0,
     ops: 0
+  },
+  removeOp: {
+    maxOp: fakeData.length,
+    executedOp: 0,
+    duration: 0,
+    ops: 0
   }
 }
 describe('SBTree - Performance - Standard Benchmark within test ', async function () {
@@ -41,29 +47,50 @@ describe('SBTree - Performance - Standard Benchmark within test ', async functio
     const writeData = JSON.parse(JSON.stringify(fakeData));
     const findData = JSON.parse(JSON.stringify(fakeData));
     const getData = JSON.parse(JSON.stringify(fakeData));
+    const removeData = JSON.parse(JSON.stringify(fakeData));
 
     const jobs = [
       ['writeOp', async () => {
-        const document = writeData.splice(Math.floor(Math.random() * (writeData.length - 1 + 1) + 0), 1)[0];
-        return tree.insertDocuments(document);
+        const len = writeData.length;
+        if (len > 0) {
+         const document = writeData.splice(Math.floor(Math.random() * (writeData.length - 1 + 1) + 0), 1)[0];
+          return tree.insertDocuments(document);
+        }
       }],
       ['getOp', async () => {
-        const data = getData.splice(Math.floor(Math.random() * (getData.length - 1 + 1) + 0), 1)[0];
-        return tree.getDocument(data._id);
+        const len = getData.length;
+        if (len > 0) {
+          const data = getData.splice(Math.floor(Math.random() * (getData.length - 1 + 1) + 0), 1)[0];
+          return tree.getDocument(data._id);
+        }
       }],
       ['findOp', async () => {
-        const rand = Math.floor(Math.random() * (findData.length - 1 + 1) + 0);
-        const query = {age:findData.splice(rand, 1)[0]};
-        return tree.findDocuments(query)
+        const len = findData.length;
+        if (len > 0) {
+          const rand = Math.floor(Math.random() * (findData.length - 1 + 1) + 0);
+          const query = {age: findData.splice(rand, 1)[0].age};
+          return tree.findDocuments(query)
+        }
+      }],
+      ['removeOp', async () => {
+        const len = removeData.length;
+        if (len > 0) {
+          const rand = Math.floor(Math.random() * (removeData.length - 1 + 1) + 0);
+          const query = {_id: removeData.splice(rand, 1)[0]._id};
+          return tree.deleteDocuments(query)
+        }
       }]
     ];
 
     const processNext = async (jobFn, jobName) => {
-      await jobFn();
-      standard[jobName].executedOp += 1;
-      if (standard[jobName].executedOp < standard[jobName].maxOp) {
-        await processNext(jobFn, jobName)
-      }
+      return new Promise(async (resolve, reject) =>{
+        await jobFn();
+        standard[jobName].executedOp += 1;
+        if (standard[jobName].executedOp < standard[jobName].maxOp) {
+          await processNext(jobFn, jobName)
+        }
+        resolve();
+      })
     };
 
     for (let _job of jobs) {
@@ -80,14 +107,15 @@ describe('SBTree - Performance - Standard Benchmark within test ', async functio
       console.log(`Finished ${jobName} in ${timer.duration.ms} ms [${standard[jobName].ops}] ops`)
     }
   });
-  it('should display result', function (done) {
-    const totalDuration = standard.writeOp.duration + standard.getOp.duration + standard.findOp.duration;
-    const totalOps = standard.writeOp.executedOp + standard.getOp.executedOp + standard.findOp.executedOp;
-    const avgOps = (standard.writeOp.ops + standard.getOp.ops + standard.findOp.ops) / 3;
+  it('should display result', async function (done) {
+    const totalDuration = standard.writeOp.duration + standard.getOp.duration + standard.findOp.duration + standard.removeOp.duration;
+    const totalOps = standard.writeOp.executedOp + standard.getOp.executedOp + standard.findOp.executedOp + standard.removeOp.executedOp;
+    const avgOps = (standard.writeOp.ops + standard.getOp.ops + standard.findOp.ops + standard.removeOp.ops) / 4;
     console.log(`======== SBTree ${version} - Benchmark from mocha`)
     console.log(`= Write : ${standard.writeOp.ops} op/s [${standard.writeOp.executedOp}]`)
     console.log(`= Get : ${standard.getOp.ops} op/s [${standard.getOp.executedOp}]`)
     console.log(`= Find : ${standard.findOp.ops} op/s [${standard.findOp.executedOp}]`)
+    console.log(`= Remove : ${standard.removeOp.ops} op/s [${standard.removeOp.executedOp}]`)
     console.log(`= ======== Summary`)
     console.log(`= Total : ${totalOps} operations`)
     console.log(`= Duration : ${totalDuration} s`)


### PR DESCRIPTION
### Issue being fixed or implemented  

At current state, it is not possible to push documents containing anything else that string or number (therefore exit any object or array). 
This PR allow us to, discarding any indexes, at least get us the data in the document when saved and prevent any error being thrown at us. 
As such, finding on a nested object is not possible at current point. We would have many incremental way to implements this, one naive being just to take not of existance of the field and traverse the whole identifiers set containing such property (and then traverse object to find data).

### What was done  

- feat: added basic nested object support
- fix: added some additional verification on returned data
- test: added remove to standard benchmark
- test: added insert / find on nested object

### How Has This Been Tested?

We added a new e2e test that test the ability to push such document.

### Notes : 

```
 SBTree - Performance - Standard Benchmark within test 
Will process 5000 elements
Finished writeOp in 179.025662 ms [27928.95691121645] ops
Finished getOp in 57.265078 ms [87313.24874821614] ops
Finished findOp in 1218.748882 ms [4102.567865986358] ops
Finished removeOp in 229.210709 ms [21813.98950255854] ops
    ✓ should be fast (1704ms)
======== SBTree 2.1.0 - Benchmark from mocha
= Write : 27928.95691121645 op/s [5000]
= Get : 87313.24874821614 op/s [5000]
= Find : 4102.567865986358 op/s [5000]
= Remove : 21813.98950255854 op/s [5000]
= ======== Summary
= Total : 20000 operations
= Duration : 1.684250331 s
= Avg : 35289.69075699437 op/s
    ✓ should display result
  SBTree - Performance - Extended Benchmark within test 
Will process 5000 elements
Finished writeOp in 93.075982 ms [53719.55140908425] ops
Finished negFindOp in 19342.125507 ms [49.11559485311946] ops
Finished gtFindOp in 15894.505307 ms [122.68390631454335] ops
Finished gteFindOp in 15133.572913 ms [125.5486731998276] ops
Finished ltFindOp in 14660.703321 ms [122.77719292100255] ops
Finished lteFindOp in 15584.713192 ms [121.91433853112645] ops
Finished inFindOp in 1029.258414 ms [1618.6411277663844] ops
Finished ninFindOp in 36113.346672 ms [36.911561038831216] ops
    ✓ should be fast (117879ms)
======== SBTree 2.1.0 - Extended
= $ne : 49.11559485311946 op/s [950]
= $gt : 122.68390631454335 op/s [1950]
= $gte : 125.5486731998276 op/s [1900]
= $lt : 122.77719292100255 op/s [1800]
= $lte : 121.91433853112645 op/s [1900]
= $in : 1618.6411277663844 op/s [1666]
= $nin : 36.911561038831216 op/s [1333]
= ======== Summary
= Total : 16499 operations
= Duration : 117.85130130799999 s
= Avg : 139.99845412720967 op/s
    ✓ should display result
  SBTree - Performance - Multi-Trees (index/field) benchmark within test 
Will process 10000 elements
Finished writeOp in 705.570184 ms [14172.934495769452] ops
Finished getOp in 138.067018 ms [72428.59406147238] ops
Finished findOp in 7041.613041 ms [1420.1291581594594] ops
    ✓ should be fast (7970ms)
======== SBTree 2.1.0 - Multi-tree Benchmark from mocha
= Write : 14172.934495769452 op/s [10000]
= Get : 72428.59406147238 op/s [10000]
= Find : 1420.1291581594594 op/s [10000]
= Total : 30000 operations
= Duration : 7.885250243 s
= Avg : 29340.552571800432 op/s
```

We lost a lot in performance here.