### PR TITLE
impr(getDocument): perform some simple optimisations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,9 @@
 ## 2.1.0 (2019-10-08)
 https://github.com/Alex-Werner/SBTree/pull/6
+https://github.com/Alex-Werner/SBTree/pull/7
 
 - feat: added basic nested object support
+- impr: performance improvements
 
 ## 2.0.1 (2019-10-08)
 https://github.com/Alex-Werner/SBTree/pull/5

--- a/src/adapters/FsAdapter/methods/getAllInLeaf.js
+++ b/src/adapters/FsAdapter/methods/getAllInLeaf.js
@@ -1,3 +1,5 @@
+const {clone} = require('lodash');
+
 module.exports = async function getAllInLeaf(leafId){
 
   let {keys} = await this.openLeafData(leafId);
@@ -6,5 +8,5 @@ module.exports = async function getAllInLeaf(leafId){
     await this.createLeaf(leafId);
     return this.getAllInLeaf(leafId);
   }
-  return JSON.parse(JSON.stringify({identifiers:this.leafs[leafId].meta.identifiers, keys:keys}));
+  return clone({identifiers:this.leafs[leafId].meta.identifiers, keys:keys});
 }

--- a/src/adapters/FsAdapter/methods/getDocument.js
+++ b/src/adapters/FsAdapter/methods/getDocument.js
@@ -1,3 +1,4 @@
-module.exports = async function getDocument(identifier){
-  return JSON.parse(JSON.stringify(await this.openDocument(identifier)));
+const {clone} = require('lodash');
+module.exports = async function getDocument(identifier) {
+  return clone(await this.openDocument(identifier));
 }

--- a/src/adapters/FsAdapter/methods/getLeftInLeaf.js
+++ b/src/adapters/FsAdapter/methods/getLeftInLeaf.js
@@ -1,3 +1,5 @@
+const {clone}= require('lodash');
+
 module.exports = async function getLeftInLeaf(leafId){
 
   let {keys} = await this.openLeafData(leafId);
@@ -11,5 +13,5 @@ module.exports = async function getLeftInLeaf(leafId){
   const identifier = leaf.meta.identifiers[0];
   const key = leaf.data.keys[0];
 
-  return JSON.parse(JSON.stringify({identifier, key }))
+  return clone({identifier, key })
 }

--- a/src/adapters/FsAdapter/methods/getRightInLeaf.js
+++ b/src/adapters/FsAdapter/methods/getRightInLeaf.js
@@ -1,3 +1,5 @@
+const {clone}= require('lodash');
+
 module.exports = async function getRightInLeaf(leafId){
 
   let {keys} = await this.openLeafData(leafId);
@@ -12,5 +14,5 @@ module.exports = async function getRightInLeaf(leafId){
   const identifier = leaf.meta.identifiers[len-1];
   const key = leaf.data.keys[len-1];
 
-  return JSON.parse(JSON.stringify({identifier, key }))
+  return clone({identifier, key })
 }

--- a/src/adapters/FsAdapter/methods/saveDatabase.js
+++ b/src/adapters/FsAdapter/methods/saveDatabase.js
@@ -1,5 +1,7 @@
+const {clone} = require('lodash');
+
 module.exports = async function saveDatabase(){
-  const leafs = JSON.parse(JSON.stringify(this.leafs))
+  const leafs = clone(this.leafs)
   const tree = this.getParent().toJSON();
   const db = {
     leafs,

--- a/src/adapters/MemoryAdapter/methods/addInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/addInLeaf.js
@@ -4,18 +4,20 @@ async function addInLeaf(leafName, identifier, value){
   if(!this.leafs[leafName]){
     await this.createLeaf(leafName);
   }
-  if(this.leafs[leafName].meta.identifiers.includes(identifier)){
+  const {meta, data} = this.leafs[leafName];
+
+  if(meta.identifiers.includes(identifier)){
     //TODO : except unique:false?
     return false;
   }
 
-  const index = insertSorted(this.leafs[leafName].data.keys, value);
+  const index = insertSorted(data.keys, value);
 
   // if(!this.documents[identifier]){
   //   this.documents[identifier] = {_id: identifier}
   // }
   // this.documents[identifier][field] = key;
-  this.leafs[leafName].meta.size +=1;
-  this.leafs[leafName].meta.identifiers.splice(index, 0, identifier);
+  meta.size +=1;
+  meta.identifiers.splice(index, 0, identifier);
 }
 module.exports = addInLeaf;

--- a/src/adapters/MemoryAdapter/methods/findInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/findInLeaf.js
@@ -2,25 +2,26 @@ const getStrictMatchingKeys = require('./ops/getStrictMatchingKeys');
 const lowerThanKeys = require('./ops/lowerThanKeys');
 const greaterThanKeys = require('./ops/greaterThanKeys');
 module.exports = async function findInLeaf(leafId, value, op = '$eq') {
-  if (!this.leafs[leafId]) {
+  const leaf = this.leafs[leafId];
+
+  if (!leaf) {
     throw new Error(`Trying to search in non-existing leafId ${leafId}`);
   }
   const result = {
     identifiers: [],
     keys: []
   };
-
-
-  const {keys} = this.leafs[leafId].data;
-  const {identifiers} = this.leafs[leafId].meta;
+  const {keys} = leaf.data;
+  const {identifiers} = leaf.meta;
   const strictMatchingKeys = getStrictMatchingKeys(keys, value);
+  const strictMatchingKeysLen = strictMatchingKeys.length;
   switch (op) {
     case "$eq":
       if (!strictMatchingKeys.length) {
         return result;
       }
       const start = strictMatchingKeys[0];
-      const end = strictMatchingKeys[0] + strictMatchingKeys.length;
+      const end = strictMatchingKeys[0] + strictMatchingKeysLen;
 
       result.identifiers.push(...identifiers.slice(start, end));
       result.keys.push(...keys.slice(start, end));
@@ -40,7 +41,7 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       // return resLte;
       return result;
     case "$lt":
-      if (strictMatchingKeys.length) {
+      if (strictMatchingKeysLen) {
         const localIndex = keys.indexOf(value);
         if (localIndex !== 0) {
           result.identifiers.push(...identifiers.slice(0, localIndex));
@@ -55,11 +56,11 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       }
       return result;
     case "$gt":
-      if (strictMatchingKeys.length) {
-        const localIndex = this.leafs[leafId].data.keys.indexOf(value);
+      if (strictMatchingKeysLen) {
+        const localIndex = keys.indexOf(value);
         if (localIndex !== -1) {
-          result.identifiers.push(...identifiers.slice(localIndex + strictMatchingKeys.length));
-          result.keys.push(...keys.slice(localIndex + strictMatchingKeys.length));
+          result.identifiers.push(...identifiers.slice(localIndex + strictMatchingKeysLen));
+          result.keys.push(...keys.slice(localIndex + strictMatchingKeysLen));
         }
       } else {
         const gtKeys = greaterThanKeys(keys, value);

--- a/src/adapters/MemoryAdapter/methods/findInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/findInLeaf.js
@@ -1,26 +1,29 @@
 const getStrictMatchingKeys = require('./ops/getStrictMatchingKeys');
 const lowerThanKeys = require('./ops/lowerThanKeys');
 const greaterThanKeys = require('./ops/greaterThanKeys');
-module.exports = async function findInLeaf(leafId, value, op = '$eq'){
-  if(!this.leafs[leafId]){
+module.exports = async function findInLeaf(leafId, value, op = '$eq') {
+  if (!this.leafs[leafId]) {
     throw new Error(`Trying to search in non-existing leafId ${leafId}`);
   }
   const result = {
-    identifiers:[],
-    keys:[]
+    identifiers: [],
+    keys: []
   };
 
-  const strictMatchingKeys = getStrictMatchingKeys(this.leafs[leafId].data.keys, value);
+
+  const {keys} = this.leafs[leafId].data;
+  const {identifiers} = this.leafs[leafId].meta;
+  const strictMatchingKeys = getStrictMatchingKeys(keys, value);
   switch (op) {
     case "$eq":
-      if(!strictMatchingKeys.length){
+      if (!strictMatchingKeys.length) {
         return result;
       }
       const start = strictMatchingKeys[0];
-      const end = strictMatchingKeys[0]+strictMatchingKeys.length;
+      const end = strictMatchingKeys[0] + strictMatchingKeys.length;
 
-      result.identifiers.push(...this.leafs[leafId].meta.identifiers.slice(start, end));
-      result.keys.push(...this.leafs[leafId].data.keys.slice(start, end));
+      result.identifiers.push(...identifiers.slice(start, end));
+      result.keys.push(...keys.slice(start, end));
 
       return result;
       // return this.leafs[leafId].meta.identifiers.slice(start, end);
@@ -29,7 +32,7 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq'){
       let resLte = [];
       resLte = resLte.concat(await this.findInLeaf(leafId, value, '$lt'));
       resLte = resLte.concat(await this.findInLeaf(leafId, value, '$eq'));
-      resLte.forEach((res)=>{
+      resLte.forEach((res) => {
         result.identifiers.push(...res.identifiers)
         result.keys.push(...res.keys)
       })
@@ -37,33 +40,33 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq'){
       // return resLte;
       return result;
     case "$lt":
-      if(strictMatchingKeys.length){
-        const localIndex = this.leafs[leafId].data.keys.indexOf(value);
-        if(localIndex!==0){
-          result.identifiers.push(...this.leafs[leafId].meta.identifiers.slice(0, localIndex));
-          result.keys.push(...this.leafs[leafId].data.keys.slice(0, localIndex));
+      if (strictMatchingKeys.length) {
+        const localIndex = keys.indexOf(value);
+        if (localIndex !== 0) {
+          result.identifiers.push(...identifiers.slice(0, localIndex));
+          result.keys.push(...keys.slice(0, localIndex));
         }
         // return (localIndex===0) ? [] : this.leafs[leafId].meta.identifiers.slice(0, localIndex-1);
-      }else{
-        const keys = lowerThanKeys(this.leafs[leafId].data.keys, value);
-        result.identifiers.push(...this.leafs[leafId].meta.identifiers.slice(0, keys.length));
-        result.keys.push(...this.leafs[leafId].data.keys.slice(0, keys.length));
+      } else {
+        const ltKeys = lowerThanKeys(keys, value);
+        result.identifiers.push(...identifiers.slice(0, ltKeys.length));
+        result.keys.push(...keys.slice(0, ltKeys.length));
         // return this.leafs[leafId].meta.identifiers.slice(0, keys.length);
       }
       return result;
     case "$gt":
-      if(strictMatchingKeys.length){
+      if (strictMatchingKeys.length) {
         const localIndex = this.leafs[leafId].data.keys.indexOf(value);
-        if(localIndex !== -1){
-          result.identifiers.push(...this.leafs[leafId].meta.identifiers.slice(localIndex+strictMatchingKeys.length));
-          result.keys.push(...this.leafs[leafId].data.keys.slice(localIndex+strictMatchingKeys.length));
+        if (localIndex !== -1) {
+          result.identifiers.push(...identifiers.slice(localIndex + strictMatchingKeys.length));
+          result.keys.push(...keys.slice(localIndex + strictMatchingKeys.length));
         }
-      }else{
-        const keys = greaterThanKeys(this.leafs[leafId].data.keys, value);
-        const len = keys.length;
-        if(leafId!==0 && len>0){
-          result.identifiers.push(...this.leafs[leafId].meta.identifiers.slice(-len));
-          result.keys.push(...this.leafs[leafId].data.keys.slice(-len));
+      } else {
+        const gtKeys = greaterThanKeys(keys, value);
+        const len = gtKeys.length;
+        if (leafId !== 0 && len > 0) {
+          result.identifiers.push(...identifiers.slice(-len));
+          result.keys.push(...keys.slice(-len));
         }
       }
       return result;
@@ -71,7 +74,7 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq'){
       let resGte = [];
       resGte = resGte.concat(await this.findInLeaf(leafId, value, '$eq'));
       resGte = resGte.concat(await this.findInLeaf(leafId, value, '$gt'));
-      resGte.forEach((res)=>{
+      resGte.forEach((res) => {
         result.identifiers.push(...res.identifiers)
         result.keys.push(...res.keys)
       })

--- a/src/adapters/MemoryAdapter/methods/getAllInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/getAllInLeaf.js
@@ -1,4 +1,6 @@
+const {clone} = require('lodash');
+
 module.exports = async function getAllInLeaf(leafId){
   const leaf = this.leafs[leafId];
-  return JSON.parse(JSON.stringify({identifiers:leaf.meta.identifiers, keys:leaf.data.keys }))
+  return clone({identifiers:leaf.meta.identifiers, keys:leaf.data.keys })
 }

--- a/src/adapters/MemoryAdapter/methods/getDocument.js
+++ b/src/adapters/MemoryAdapter/methods/getDocument.js
@@ -1,7 +1,8 @@
-module.exports = async function getDocument(identifier){
+const {clone}= require('lodash');
+module.exports = async function getDocument(identifier) {
   const doc = this.documents[identifier];
-  if(doc){
-    return JSON.parse(JSON.stringify(this.documents[identifier]));
+  if (!doc) {
+    return {_id: identifier};
   }
-  return {_id:identifier};
+  return clone(doc);
 };

--- a/src/adapters/MemoryAdapter/methods/getLeftInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/getLeftInLeaf.js
@@ -3,8 +3,11 @@ const {clone} = require('lodash');
 module.exports = async function getLeftInLeaf(leafId){
   const leaf = this.leafs[leafId];
 
-  const identifier = leaf.meta.identifiers[0];
-  const key = leaf.data.keys[0];
+  const {meta, data} = leaf;
+  const {identifiers} = meta;
+
+  const identifier = identifiers[0];
+  const key = data.keys[0];
 
   return clone({identifier, key })
 }

--- a/src/adapters/MemoryAdapter/methods/getLeftInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/getLeftInLeaf.js
@@ -1,8 +1,10 @@
+const {clone} = require('lodash');
+
 module.exports = async function getLeftInLeaf(leafId){
   const leaf = this.leafs[leafId];
 
   const identifier = leaf.meta.identifiers[0];
   const key = leaf.data.keys[0];
 
-  return JSON.parse(JSON.stringify({identifier, key }))
+  return clone({identifier, key })
 }

--- a/src/adapters/MemoryAdapter/methods/getRightInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/getRightInLeaf.js
@@ -1,11 +1,14 @@
 const {clone} = require('lodash');
 
-module.exports = async function getRightInLeaf(leafId){
+module.exports = async function getRightInLeaf(leafId) {
   const leaf = this.leafs[leafId];
 
-  const len = leaf.meta.identifiers.length;
-  const identifier = leaf.meta.identifiers[len-1];
-  const key = leaf.data.keys[len-1];
+  const {meta, data} = leaf;
+  const {identifiers} = meta;
 
-  return clone({identifier, key })
+  const len = identifiers.length;
+  const identifier = identifiers[len - 1];
+  const key = data.keys[len - 1];
+
+  return clone({identifier, key})
 }

--- a/src/adapters/MemoryAdapter/methods/getRightInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/getRightInLeaf.js
@@ -1,3 +1,5 @@
+const {clone} = require('lodash');
+
 module.exports = async function getRightInLeaf(leafId){
   const leaf = this.leafs[leafId];
 
@@ -5,5 +7,5 @@ module.exports = async function getRightInLeaf(leafId){
   const identifier = leaf.meta.identifiers[len-1];
   const key = leaf.data.keys[len-1];
 
-  return JSON.parse(JSON.stringify({identifier, key }))
+  return clone({identifier, key })
 }

--- a/src/adapters/MemoryAdapter/methods/removeInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/removeInLeaf.js
@@ -3,11 +3,12 @@ async function removeInLeaf(leafId, identifier) {
   if (!this.leafs[leafId]) {
     throw new Error('Trying to remove in unknown leaf id')
   }
+  const {meta, data} = this.leafs[leafId];
     const index = this.leafs[leafId].meta.identifiers.indexOf(identifier);
     if (index >= 0) {
-      this.leafs[leafId].meta.size -= 1;
-      this.leafs[leafId].meta.identifiers.splice(index, 1);
-      this.leafs[leafId].data.keys.splice(index, 1);
+      meta.size -= 1;
+      meta.identifiers.splice(index, 1);
+      data.keys.splice(index, 1);
       identifiers.push({identifier, index});
     }
   return identifiers;

--- a/src/adapters/MemoryAdapter/methods/saveDocument.js
+++ b/src/adapters/MemoryAdapter/methods/saveDocument.js
@@ -1,7 +1,6 @@
 async function saveDocument(doc){
-  const identifier = doc._id;
-  if(!this.documents[identifier]){
-    this.documents[identifier] = doc;
+  if(!this.documents[doc._id]){
+    this.documents[doc._id] = doc;
   }
 }
-module.exports = saveDocument
+module.exports = saveDocument;

--- a/src/adapters/MemoryAdapter/methods/splitLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/splitLeaf.js
@@ -1,26 +1,30 @@
-module.exports = async function splitLeaf(sourceLeaf, siblingLeaf){
-  if(!this.leafs[sourceLeaf.id]){
+module.exports = async function splitLeaf(sourceLeaf, siblingLeaf) {
+  if (!this.leafs[sourceLeaf.id]) {
     throw new Error(`Source leaf do not exist`)
   }
   const source = this.leafs[sourceLeaf.id];
-  if(!this.leafs[siblingLeaf.id]){
+  const {keys} = source.data;
+  const {identifiers} = source.meta;
+
+  const sibling = this.leafs[siblingLeaf.id];
+
+  if (!sibling) {
     throw new Error(`Sibbling leaf do not exist`);
   }
-  const sibling = this.leafs[siblingLeaf.id];
-  const midIndex = ~~(source.data.keys.length/2);
+  const midIndex = ~~(keys.length / 2);
 
   // console.log(this.leafs,sourceLeaf.name,{source:source.data.keys})
   // console.dir(this, {depth:null});
 
-  const rightKeys = source.data.keys.splice(midIndex);
-  const rightIdentifiers = source.meta.identifiers.splice(midIndex);
-  const midKey = rightKeys.slice(0,1)[0];
+  const rightKeys = keys.splice(midIndex);
+  const rightIdentifiers = identifiers.splice(midIndex);
+  const midKey = rightKeys.slice(0, 1)[0];
 
   sibling.data.keys = rightKeys;
   sibling.meta.size = rightIdentifiers.length;
   sibling.meta.identifiers = rightIdentifiers;
 
-  source.meta.size = source.meta.identifiers.length
+  source.meta.size = identifiers.length
 
   return midKey;
 }

--- a/src/types/SBFLeaf/methods/getFillStatus.js
+++ b/src/types/SBFLeaf/methods/getFillStatus.js
@@ -11,12 +11,12 @@ async function getFillStatus() {
 
   try {
     const leaf = await adapter.openLeaf(this.id);
-
+    const {size} = leaf.meta;
     return {
       fillFactor,
       order,
-      leafSize: leaf.meta.size,
-      fillFactorFilled: leaf.meta.size >= minKeys
+      leafSize: size,
+      fillFactorFilled: size >= minKeys
     };
   } catch (e) {
     if (e.message === 'Leaf do not exist') {

--- a/src/types/SBFLeaf/methods/mergeWithSiblings.js
+++ b/src/types/SBFLeaf/methods/mergeWithSiblings.js
@@ -1,6 +1,5 @@
 async function mergeWithSiblings(){
   const parent = this.getParent();
-  const adapter = parent.getAdapter();
 
   const selfId = this.id;
   const selfPos = parent.childrens.findIndex((el)=> el.id === selfId);

--- a/src/types/SBFLeaf/methods/redistribute.js
+++ b/src/types/SBFLeaf/methods/redistribute.js
@@ -7,7 +7,6 @@
 async function redistribute(){
   // console.log('Leaf - redistribute')
   const parent = this.getParent();
-  const adapter = parent.getAdapter();
 
   const selfId = this.id;
   const selfPos = parent.childrens.findIndex((el)=> el.id === selfId);

--- a/src/types/SBFNode/methods/find.js
+++ b/src/types/SBFNode/methods/find.js
@@ -1,12 +1,12 @@
 module.exports = async function find(value){
   const results = {identifiers:[], keys:[]};
-
+  const {childrens} = this;
   let leafIndex = 0;
   this.keys.forEach((_key)=>{
     if(value<=_key) return;
     leafIndex++;
   });
-  const leaf = this.childrens[leafIndex];
+  const leaf = childrens[leafIndex];
 
   // const leaf = this.childrens[leafIndex];
   let leftRes = await leaf.find(value);
@@ -20,8 +20,8 @@ module.exports = async function find(value){
   //   result = result.concat(await left.find(key));
   // }
   // We also check the leaf nearby
-  if(this.childrens.length>leafIndex+1){
-    const right = this.childrens[leafIndex+1];
+  if(childrens.length>leafIndex+1){
+    const right = childrens[leafIndex+1];
     const rightRes = await right.find(value);
     results.identifiers.push(...rightRes.identifiers)
     results.keys.push(...rightRes.keys)

--- a/src/types/SBFNode/methods/findGreaterThan.js
+++ b/src/types/SBFNode/methods/findGreaterThan.js
@@ -1,23 +1,24 @@
-async function findGreaterThan(value,includeKey=false) {
+async function findGreaterThan(value, includeKey = false) {
   let result = [];
+  const {childrens, keys} = this;
 
   let leafIndex = 0;
   let p = [];
   // It might be a bug that we have no keys, but in this case, we take first child
-  if(this.keys.length===0 && this.childrens.length===1){
-    p.push(this.childrens[0].findLowerThan(value, includeKey));
-  }else{
+  if (keys.length === 0 && childrens.length === 1) {
+    p.push(childrens[0].findLowerThan(value, includeKey));
+  } else {
     // Let's find our first match leaf
-    this.keys.forEach((_key) => {
+    keys.forEach((_key) => {
       if (value <= _key) return;
       leafIndex++;
     });
 
     // We lookup in our children
-    p.push(this.childrens[leafIndex].findGreaterThan(value, includeKey));
+    p.push(childrens[leafIndex].findGreaterThan(value, includeKey));
 
     // And all greater value
-    this.childrens.slice(leafIndex+1).forEach((child) => {
+    childrens.slice(leafIndex + 1).forEach((child) => {
       p.push(child.findAll())
     });
 
@@ -32,4 +33,5 @@ async function findGreaterThan(value,includeKey=false) {
   });
   return result;
 }
+
 module.exports = findGreaterThan

--- a/src/types/SBFNode/methods/findLowerThan.js
+++ b/src/types/SBFNode/methods/findLowerThan.js
@@ -1,29 +1,29 @@
-async function findLowerThan(value,includeKey=false) {
-  let result = {identifiers:[], keys:[]};
-
+async function findLowerThan(value, includeKey = false) {
+  let result = {identifiers: [], keys: []};
+  const {childrens, keys} = this;
   let leafIndex = 0;
   let p = [];
   // It might be a bug that we have no keys, but in this case, we take first child
-  if(this.keys.length===0 && this.childrens.length===1){
-    p.push(this.childrens[0].findLowerThan(value, includeKey));
-  }else{
+  if (keys.length === 0 && childrens.length === 1) {
+    p.push(childrens[0].findLowerThan(value, includeKey));
+  } else {
     // Let's find our first match leaf
-    this.keys.forEach((_key) => {
+    keys.forEach((_key) => {
       if (value <= _key) return;
       leafIndex++;
     });
 
     // We first look up all smaller value
-    this.childrens.slice(0,leafIndex).forEach((child) => {
+    childrens.slice(0, leafIndex).forEach((child) => {
       p.push(child.findAll())
     });
 
     // And then we lookup in our children
-    p.push(this.childrens[leafIndex].findLowerThan(value, includeKey));
+    p.push(childrens[leafIndex].findLowerThan(value, includeKey));
 
     // And the next one if it exist (in case we got duplicate same value
-    if(this.childrens[leafIndex+1]){
-      p.push(this.childrens[leafIndex+1].findLowerThan(value, includeKey));
+    if (childrens[leafIndex + 1]) {
+      p.push(childrens[leafIndex + 1].findLowerThan(value, includeKey));
     }
   }
   await Promise.all(p).then((res) => {
@@ -35,4 +35,5 @@ async function findLowerThan(value,includeKey=false) {
   });
   return result;
 }
+
 module.exports = findLowerThan

--- a/src/types/SBFNode/methods/getFillStatus.js
+++ b/src/types/SBFNode/methods/getFillStatus.js
@@ -10,8 +10,8 @@ const getFillStatus = async function(){
 
   try {
     const leaf = await adapter.openLeaf(this.id);
-
-    return {fillFactor, order, leafSize:leaf.meta.size, fillFactorFilled: leaf.meta.size>=minKeys};
+    const {size} = leaf.meta;
+    return {fillFactor, order, leafSize:size, fillFactorFilled: size>=minKeys};
   }catch (e) {
     if(e.message === 'Leaf do not exist'){
       await adapter.createLeaf(this.id);

--- a/src/types/SBFNode/methods/insert.js
+++ b/src/types/SBFNode/methods/insert.js
@@ -1,18 +1,19 @@
 const SBFLeaf = require('../../SBFLeaf/SBFLeaf');
 module.exports = async function insert(identifier,value){
-  if(!this.childrens.length){
+  const {childrens, keys} = this;
+  if(!childrens.length){
     const leaf = new SBFLeaf({parent: this});
     await leaf.insert(identifier, value);
-    this.childrens.push(leaf);
+    childrens.push(leaf);
     // this.keys.push(value);
     // throw new Error(`SBFNode cannot insert with no childrens`);
   }
   let leafIndex = 0;
-  this.keys.forEach((_key)=>{
+  keys.forEach((_key)=>{
     if(value<=_key) return;
     leafIndex++;
   });
-  const leaf = this.childrens[leafIndex];
+  const leaf = childrens[leafIndex];
   await leaf.insert(identifier, value);
 
   if(this.isFull()){

--- a/src/types/SBFNode/methods/mergeUp.js
+++ b/src/types/SBFNode/methods/mergeUp.js
@@ -8,7 +8,7 @@
 const mergeUp = async function(){
   // console.log('Node - Merge up')
   const parent = this.getParent();
-  const {childrens, keys, id}= this;
+  const {childrens, id}= this;
   // const
   const selfPos = parent.childrens.findIndex((el)=> el.id === id);
   if(childrens.length!==1){

--- a/src/types/SBFRoot/methods/find.js
+++ b/src/types/SBFRoot/methods/find.js
@@ -1,7 +1,7 @@
 const findEquals = require('./ops/findEquals');
 const findLowerThan = require('./ops/findLowerThan');
 const findGreaterThan = require('./ops/findGreaterThan');
-const {xor, difference, pullAll} = require('lodash');
+
 async function find(value, operator = '$eq'){
   const self = this;
   const p = [];

--- a/src/types/SBFRoot/methods/getFillStatus.js
+++ b/src/types/SBFRoot/methods/getFillStatus.js
@@ -1,13 +1,12 @@
 const getFillStatus = async function(){
-  const adapter = this.getAdapter();
   const {fillFactor,order} = this.getTreeOptions();
   if(fillFactor<0.5){
     throw new Error(`FillFactor cannot be less than 0.5. Received ${fillFactor}`)
   }
   const maxKeys = order - 1;
   const minKeys = Math.floor(maxKeys * fillFactor);
-
-  return {fillFactor, order, leafSize:this.keys.length, fillFactorFilled: this.keys.length>=minKeys};
+  const size = this.keys.length;
+  return {fillFactor, order, leafSize:size, fillFactorFilled: size>=minKeys};
 
 };
 module.exports = getFillStatus;

--- a/src/types/SBFRoot/methods/insert.js
+++ b/src/types/SBFRoot/methods/insert.js
@@ -1,8 +1,6 @@
-const SBFLeaf = require('../../SBFLeaf/SBFLeaf');
-
 async function insert(identifier, value = null){
-
-  if(this.childrens.length===0){
+  const {childrens} = this;
+  if(childrens.length===0){
 
     // if(this.keys.length===0){
       const idx = await this.insertReferenceKey(value)
@@ -19,7 +17,7 @@ async function insert(identifier, value = null){
       if(value<=_key) return;
       leafIndex++;
     });
-    const leaf = this.childrens[leafIndex];
+    const leaf = childrens[leafIndex];
     await leaf.insert(identifier, value);
 
   }

--- a/src/types/SBFRoot/methods/ops/findEquals.js
+++ b/src/types/SBFRoot/methods/ops/findEquals.js
@@ -1,19 +1,19 @@
 module.exports = async function findEquals(value){
   let result = {identifiers:[], keys:[]};
+  const {childrens, identifiers, keys} = this;
 
   let leafIndex = 0;
-  this.keys.forEach((_key)=>{
+  keys.forEach((_key)=>{
     if(value<=_key) return;
     leafIndex++;
   });
 
   let p = []
 
-  const {childrens} = this;
   if(childrens.length===0){
-    if(this.identifiers[leafIndex]){
-      result.identifiers.push(this.identifiers[leafIndex])
-      result.keys.push(this.keys[leafIndex])
+    if(identifiers[leafIndex]){
+      result.identifiers.push(identifiers[leafIndex])
+      result.keys.push(keys[leafIndex])
     }
   }else{
     const left = childrens[leafIndex];

--- a/src/types/SBFRoot/methods/ops/findGreaterThan.js
+++ b/src/types/SBFRoot/methods/ops/findGreaterThan.js
@@ -1,10 +1,10 @@
 async function findGreaterThan(key, includeKey=false){
   let result = {identifiers:[], keys:[]};
-
+  const {childrens, keys} = this;
   // We first see where our key is located;
   let leafIndex = 0;
 
-  this.keys.forEach((_key)=>{
+  keys.forEach((_key)=>{
     if(key<=_key) return;
     leafIndex++;
   });
@@ -13,19 +13,19 @@ async function findGreaterThan(key, includeKey=false){
   let p = [];
 
   // first, we lookup for all greater than matches in the actual leaf where we had our el.
-  p.push(this.childrens[leafIndex].findGreaterThan(key, includeKey));
+  p.push(childrens[leafIndex].findGreaterThan(key, includeKey));
 
   // If our key is in the keys, then right item will contains our key and it's superior elements
   // We need this extra step first
   let start = leafIndex+1;
-  if(this.keys.includes(key)){
+  if(keys.includes(key)){
 
-    p.push(this.childrens[start].findGreaterThan(key, includeKey));
+    p.push(childrens[start].findGreaterThan(key, includeKey));
     start+=1;
   }
   // All bigger leaf that our leafIndex needs to be included
-  if(leafIndex<this.childrens.length-1){
-    this.childrens.slice(start).forEach((child, i)=>{
+  if(leafIndex<childrens.length-1){
+    childrens.slice(start).forEach((child, i)=>{
       p.push(child.getAll());
     });
   }

--- a/src/types/SBFRoot/methods/ops/findLowerThan.js
+++ b/src/types/SBFRoot/methods/ops/findLowerThan.js
@@ -1,33 +1,33 @@
-const {difference} = require('lodash');
-async function findLowerThan(key, includeKey=false){
-  let result = {identifiers:[],keys:[]};
+async function findLowerThan(key, includeKey = false) {
+  let result = {identifiers: [], keys: []};
+  const {childrens, keys} = this;
 
   // We first see where our key is located;
   let leafIndex = 0;
 
-  this.keys.forEach((_key)=>{
-    if(key<=_key) return;
+  keys.forEach((_key) => {
+    if (key <= _key) return;
     leafIndex++;
   });
 
   let p = [];
 
   // All smaller leaf that our leafIndex needs to be included
-  if(leafIndex>=1){
-    this.childrens.slice(0, leafIndex).forEach((child)=>{
+  if (leafIndex >= 1) {
+    childrens.slice(0, leafIndex).forEach((child) => {
       p.push(child.getAll());
     });
   }
 
   // Finally, we lookup for all lower than matches in the actual leaf where we had our el.
-  p.push(this.childrens[leafIndex].findLowerThan(key, includeKey));
+  p.push(childrens[leafIndex].findLowerThan(key, includeKey));
 
-  if(this.keys.includes(key)){
-    p.push(await this.childrens[leafIndex+1].findLowerThan(key, includeKey));
+  if (keys.includes(key)) {
+    p.push(await childrens[leafIndex + 1].findLowerThan(key, includeKey));
   }
 
-  await Promise.all(p).then((res)=>{
-    res.forEach((p)=>{
+  await Promise.all(p).then((res) => {
+    res.forEach((p) => {
       result.identifiers.push(...p.identifiers);
       result.keys.push(...p.keys);
     })

--- a/src/types/SBFRoot/methods/remove.js
+++ b/src/types/SBFRoot/methods/remove.js
@@ -1,19 +1,19 @@
 async function remove(remCmd){
   const value = remCmd.query[this.fieldName];
-
+  const {keys, childrens} = this;
   let leafIndex = 0;
-  this.keys.forEach((_key)=>{
+  keys.forEach((_key)=>{
     if(value<_key) return;
     leafIndex++;
   });
 
-  const leaf = this.childrens[leafIndex];
+  const leaf = childrens[leafIndex];
   if(leaf){
     await leaf.remove(remCmd);
 
     // This has been added for the case where previous also contains the same value
-    if(this.childrens[leafIndex-1]){
-      await this.childrens[leafIndex-1].remove(remCmd);
+    if(childrens[leafIndex-1]){
+      await childrens[leafIndex-1].remove(remCmd);
     }
   }
 };

--- a/src/types/SBFRoot/methods/split.js
+++ b/src/types/SBFRoot/methods/split.js
@@ -1,47 +1,49 @@
 const SBFNode = require('../../SBFNode/SBFNode');
 const SBFLeaf = require('../../SBFLeaf/SBFLeaf');
 const {forEach} = require('../../../utils/array');
-async function split() {
-  const midIndex = ~~(this.keys.length / 2);
-  const rightKeys = this.keys.splice(midIndex);
-  const leftKeys = this.keys.splice(0);
 
-  if(this.childrens.length>0)
-  {
+async function split() {
+  const {childrens, identifiers, keys, fieldName} = this;
+
+  const midIndex = ~~(keys.length / 2);
+  const rightKeys = keys.splice(midIndex);
+  const leftKeys = keys.splice(0);
+
+  if (childrens.length > 0) {
     const midKey = rightKeys.splice(0, 1)[0];
 
-    const rightChildrens = this.childrens.splice(midIndex + 1);
-    const leftChildrens = this.childrens.splice(0);
+    const rightChildrens = childrens.splice(midIndex + 1);
+    const leftChildrens = childrens.splice(0);
 
 
-    const right = new SBFNode({fieldName: this.fieldName, parent: this});
+    const right = new SBFNode({fieldName: fieldName, parent: this});
     right.keys = rightKeys;
     right.childrens = rightChildrens;
     rightChildrens.forEach((child) => {
       child.setParent(right);
     })
 
-    const left = new SBFNode({fieldName: this.fieldName, parent: this});
+    const left = new SBFNode({fieldName: fieldName, parent: this});
     left.keys = leftKeys;
     left.childrens = leftChildrens;
     leftChildrens.forEach((child) => {
       child.setParent(left);
     })
 
-    this.keys.push(midKey);
+    keys.push(midKey);
     this.childrens = [left, right];
 
-  }else{
+  } else {
     const midKey = rightKeys.slice(0)[0];
 
-    const rightIdentifiers = this.identifiers.splice(midIndex);
-    const leftIdentifiers = this.identifiers.splice(0);
+    const rightIdentifiers = identifiers.splice(midIndex);
+    const leftIdentifiers = identifiers.splice(0);
 
     const right = new SBFLeaf({parent: this});
     //FIXME
     await this.getAdapter().createLeaf(right.id);
 
-    await forEach(rightKeys, async (key,i)=>{
+    await forEach(rightKeys, async (key, i) => {
       await right.insert(rightIdentifiers[i], key);
     })
 
@@ -49,12 +51,12 @@ async function split() {
     const left = new SBFLeaf({parent: this});
     await this.getAdapter().createLeaf(left.id);
 
-    await forEach(leftKeys, async (key,i)=>{
+    await forEach(leftKeys, async (key, i) => {
       await left.insert(leftIdentifiers[i], key);
     })
 
 
-    this.keys.push(midKey);
+    keys.push(midKey);
 
     this.childrens = [left, right];
   }

--- a/src/types/SBFTree/methods/insert.js
+++ b/src/types/SBFTree/methods/insert.js
@@ -1,6 +1,8 @@
 module.exports = async function insert(identifier, value){
-  if(!this.root){
+  let root = this.root;
+  if(!root){
     this.createRoot();
+     root = this.root;
   }
   if(this.isUnique){
     const get = await this.find(value, '$eq');
@@ -8,5 +10,5 @@ module.exports = async function insert(identifier, value){
       return false
     }
   }
-  await this.root.insert(identifier, value);
+  await root.insert(identifier, value);
 }

--- a/src/types/SBTree/methods/getDocument.js
+++ b/src/types/SBTree/methods/getDocument.js
@@ -1,6 +1,11 @@
 const get = require('../ops/get');
+const {waitFor} = require('../../../utils/fn');
 
 async function getDocument(identifier){
+  if(!this.isReady){
+    await waitFor(this, 'isReady');
+  }
+
   return (await get.call(this,identifier));
 };
 module.exports = getDocument;

--- a/src/types/SBTree/methods/insertDocuments.js
+++ b/src/types/SBTree/methods/insertDocuments.js
@@ -1,6 +1,5 @@
 const ObjectId = require('mongo-objectid');
 const insert = require('../ops/insert');
-const {map} = require('lodash');
 const {waitFor} = require('../../../utils/fn');
 const {clone}= require('lodash');
 

--- a/src/types/SBTree/methods/insertDocuments.js
+++ b/src/types/SBTree/methods/insertDocuments.js
@@ -2,6 +2,7 @@ const ObjectId = require('mongo-objectid');
 const insert = require('../ops/insert');
 const {map} = require('lodash');
 const {waitFor} = require('../../../utils/fn');
+const {clone}= require('lodash');
 
 async function insertDocuments(documents) {
   // This will wait for SBTree to have isReady = true.
@@ -16,7 +17,7 @@ async function insertDocuments(documents) {
     }
     return documents;
   }
-  const document = JSON.parse(JSON.stringify(documents));
+  const document = clone(documents);
 
   if (!document._id) {
     document._id = new ObjectId().toString();

--- a/src/types/SBTree/ops/get.js
+++ b/src/types/SBTree/ops/get.js
@@ -1,24 +1,8 @@
 async function get(identifier) {
   if (!identifier) throw new Error('Expected an objectid')
 
-  let document = {
-    _id: identifier
-  };
   const res = await this.adapter.getDocument(identifier);
 
   return res || false;
-
-  // for(const field in this.fieldTrees){
-  //   const data = await this.fieldTrees[field].get(id);
-  //   document = Object.assign(document, data);
-  // }
-  // await Promise.all(map(this.fieldTrees, async (fieldTree) => {
-  //       const {field} = fieldTree;
-  //       if (this.options.verbose) console.log(`Seeking for ${id} in ${field}`);
-  //       const data = await fieldTree.get(id);
-  //       document = Object.assign(document, data);
-  //     }
-  // ));
-  // return document;
 };
 module.exports = get;

--- a/src/types/SBTree/ops/insert.js
+++ b/src/types/SBTree/ops/insert.js
@@ -1,5 +1,3 @@
-const {map} = require('lodash')
-
 async function insert(document) {
   if(!document){
     throw new Error('Cannot insert empty document');

--- a/src/types/SBTree/ops/query.js
+++ b/src/types/SBTree/ops/query.js
@@ -73,7 +73,6 @@ async function query(query) {
     listOfFieldLookup = listOfFieldLookup.concat(fieldLookup);
   }
   const matchingObjectIds = findIntersectingIdentifiers(listOfFieldLookup);
-  const documents = await resolveDocuments(self, matchingObjectIds);
-  return documents;
+  return resolveDocuments(self, matchingObjectIds);
 };
 module.exports = query;

--- a/src/types/SBTree/ops/query.js
+++ b/src/types/SBTree/ops/query.js
@@ -36,7 +36,8 @@ async function query(query) {
     }
 
     // We try to look up the easy cases, strict equality
-    if (['string', 'number'].includes(typeof queryFieldValue)) {
+    const queryFieldType = typeof queryFieldValue
+    if (['string', 'number'].includes(queryFieldType)) {
 
       let operator = '$eq';
       const value = await fieldTree.find(queryFieldValue, operator);
@@ -49,7 +50,7 @@ async function query(query) {
       }
     } else {
       if (Array.isArray(queryFieldValue)) throw new Error(`Not supported array input. Please open a Github issue to specify your need.`);
-      if (typeof queryFieldValue === "object" && !Array.isArray(queryFieldValue)) {
+      if (queryFieldType === "object" && !Array.isArray(queryFieldValue)) {
         const operators = Object.keys(queryFieldValue).filter((el) => el[0] === '$');
 
         // TODO : Move to Promise.all. Expect changes, no point to not parallel the calls. We use this for now.

--- a/src/types/SBTree/ops/remove.js
+++ b/src/types/SBTree/ops/remove.js
@@ -1,6 +1,4 @@
-const {map} = require('lodash')
 const query = require('./query')
-const ascii = require('../../../utils/ascii');
 
 class RemoveCommand {
   constructor(res) {


### PR DESCRIPTION
### Issue being fixed or implemented  

With the previous PR, we noticed a huge drop in performance. 
Let's try to improve that again with some easy stuff.

### What was done  

- Impr: basic optimisation property access
- Impr: moved from JSON.parse/stringify to lodash.clone
- Impr(getDocument): basic optimisation

### Notes 

= Write : from 27928 op/s to 32710
= Get : from  87313 op/s to 98294
= Find : from  4102 op/s to 5173 *(still something wrong here)*
= Remove : from 21813 op/s to 27423

Which is still lower than before our remove PR. We should stop calling parents and such now. 
And probably we should hold size locally in the leaf if we want to deeply increase performance, as this is probably what is the most expensive here (all the check about if we should split)

```
SBTree - Performance - Standard Benchmark within test 
Will process 5000 elements
Finished writeOp in 152.854273 ms [32710.894513233525] ops
Finished getOp in 50.86749 ms [98294.60820653822] ops
Finished findOp in 966.539273 ms [5173.095537526078] ops
Finished removeOp in 182.324392 ms [27423.64828508519] ops
    ✓ should be fast (1368ms)
======== SBTree 2.1.0 - Benchmark from mocha
= Write : 32710.894513233525 op/s [5000]
= Get : 98294.60820653822 op/s [5000]
= Find : 5173.095537526078 op/s [5000]
= Remove : 27423.64828508519 op/s [5000]
= ======== Summary
= Total : 20000 operations
= Duration : 1.3525854279999998 s
= Avg : 40900.56163559575 op/s
    ✓ should display result
  SBTree - Performance - Extended Benchmark within test 
Will process 5000 elements
Finished writeOp in 84.33234 ms [59289.235896928745] ops
Finished negFindOp in 12443.840449 ms [76.34299104793995] ops
Finished gtFindOp in 8115.82427 ms [240.2713433813667] ops
Finished gteFindOp in 8348.919013 ms [227.57437184880257] ops
Finished ltFindOp in 7504.089613 ms [239.86920370483057] ops
Finished lteFindOp in 8121.887607 ms [233.93576615889756] ops
Finished inFindOp in 749.20079 ms [2223.7029408364615] ops
Finished ninFindOp in 28864.498073 ms [46.18129844588897] ops
    ✓ should be fast (74263ms)
======== SBTree 2.1.0 - Extended
= $ne : 76.34299104793995 op/s [950]
= $gt : 240.2713433813667 op/s [1950]
= $gte : 227.57437184880257 op/s [1900]
= $lt : 239.86920370483057 op/s [1800]
= $lte : 233.93576615889756 op/s [1900]
= $in : 2223.7029408364615 op/s [1666]
= $nin : 46.18129844588897 op/s [1333]
= ======== Summary
= Total : 16499 operations
= Duration : 74.23259215499999 s
= Avg : 222.26086306604475 op/s
    ✓ should display result
  SBTree - Performance - Multi-Trees (index/field) benchmark within test 
Will process 10000 elements
Finished writeOp in 562.719241 ms [17770.851379151612] ops
Finished getOp in 101.559549 ms [98464.39944312868] ops
Finished findOp in 3474.061081 ms [2878.475584292699] ops
    ✓ should be fast (4202ms)
======== SBTree 2.1.0 - Multi-tree Benchmark from mocha
= Write : 17770.851379151612 op/s [10000]
= Get : 98464.39944312868 op/s [10000]
= Find : 2878.475584292699 op/s [10000]
= Total : 30000 operations
= Duration : 4.1383398709999994 s
= Avg : 39704.57546885766 op/s
    ✓ should display result
```