### PR TITLE
Impr: nested object handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 
 > Fast document store using B+ Tree for fields. Adapters support for In-Memory and FileSystem 
 
-Complexity : `O(log(n))` - Help welcome to pass it `O(n)`.  
-State : NOT FOR PRODUCTION (see remaining TODO / FIXME / ISSUES).
+State : Not battle tested on production. Many optimisation still to be done.
 
 This library's goal is to provide a way to quickly store document-based data in-memory or on the filesystem.  
 It uses a field-specific indexing system relaying on B+Tree structure.  
 This allow to handle a lot of data, and have them indexed without the need to keep the whole dataset in-memory. 
 Most of the databases uses B-Tree (MongoDB, CouchDB) or B+Tree (InnoDB, MariaDB, MySQL).
 
-Note : By default. Everything except specifically excluded field are indexed    
+Note : By default. Everything except specifically excluded field are indexed.  
+Nested object are also indexed.    
 Optional support for uniques key provided.    
 
 ### Table of Contents
@@ -71,6 +71,9 @@ const start = async function () {
 
   alex.age = 29;
   const replaceRes = await tree.replaceDocuments(alex)
+
+  await tree.insertDocuments({name:'John', nestedField:{isNested:{itIs:true}}});
+  const [john] = await tree.findDocuments({nestedField:{isNested:{itIs:true}}});
 
 }
 tree.on('ready', start);

--- a/examples/basic-usage.js
+++ b/examples/basic-usage.js
@@ -8,7 +8,6 @@ const timer = new Timer();
 const start = async function () {
   timer.start();
 
-
   await tree.insertDocuments({age:43, country:'United States', email:'bob@valjean.fr', _id:'5d6dc94e3c7734812f051d7b'});
   await tree.insertDocuments({age:21, country:'Russia',email:'julia@valjean.fr', _id:'5d6dc94e3c7734812f051d7c'});
   await tree.insertDocuments({age:22, country:'United Kingdom',email:'zack@valjean.fr', _id:'5d6dc94e3c7734812f051duk'});

--- a/examples/basic-usage.js
+++ b/examples/basic-usage.js
@@ -8,6 +8,7 @@ const timer = new Timer();
 const start = async function () {
   timer.start();
   console.log('-- Inserting...')
+
   await tree.insertDocuments({age:43, country:'United States', email:'bob@valjean.fr', _id:'5d6dc94e3c7734812f051d7b'});
   await tree.insertDocuments({age:21, country:'Russia',email:'julia@valjean.fr', _id:'5d6dc94e3c7734812f051d7c'});
   await tree.insertDocuments({age:22, country:'United Kingdom',email:'zack@valjean.fr', _id:'5d6dc94e3c7734812f051duk'});
@@ -75,8 +76,9 @@ const start = async function () {
   console.log('-- Find : {canDeliver:true}');
   console.log(await tree.findDocuments({canDeliver:true}));
 
-  console.log('-- Update : {canDeliver:true}, {$set:{canDeliver:false}}');
+  // console.log('-- Update : {canDeliver:true}, {$set:{canDeliver:false}}');
   // console.log(await tree.updateDocuments({canDeliver:true}));
+
 
   timer.stop();
   console.log(timer.duration.s, 'seconds');

--- a/examples/basic-usage.js
+++ b/examples/basic-usage.js
@@ -7,7 +7,7 @@ const timer = new Timer();
 
 const start = async function () {
   timer.start();
-  console.log('-- Inserting...')
+
 
   await tree.insertDocuments({age:43, country:'United States', email:'bob@valjean.fr', _id:'5d6dc94e3c7734812f051d7b'});
   await tree.insertDocuments({age:21, country:'Russia',email:'julia@valjean.fr', _id:'5d6dc94e3c7734812f051d7c'});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtree",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtree",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Optimised document store using B+ Tree for fields. Adapters support for In-Memory and FileSystem",
   "main": "index.js",
   "scripts": {

--- a/src/adapters/FsAdapter/methods/getAllInLeaf.js
+++ b/src/adapters/FsAdapter/methods/getAllInLeaf.js
@@ -1,4 +1,4 @@
-const {clone} = require('lodash');
+const {cloneDeep} = require('lodash');
 
 module.exports = async function getAllInLeaf(leafId){
 
@@ -8,5 +8,5 @@ module.exports = async function getAllInLeaf(leafId){
     await this.createLeaf(leafId);
     return this.getAllInLeaf(leafId);
   }
-  return clone({identifiers:this.leafs[leafId].meta.identifiers, keys:keys});
+  return cloneDeep({identifiers:this.leafs[leafId].meta.identifiers, keys:keys});
 }

--- a/src/adapters/FsAdapter/methods/getDocument.js
+++ b/src/adapters/FsAdapter/methods/getDocument.js
@@ -1,4 +1,4 @@
-const {clone} = require('lodash');
+const {cloneDeep} = require('lodash');
 module.exports = async function getDocument(identifier) {
-  return clone(await this.openDocument(identifier));
+  return cloneDeep(await this.openDocument(identifier));
 }

--- a/src/adapters/FsAdapter/methods/getLeftInLeaf.js
+++ b/src/adapters/FsAdapter/methods/getLeftInLeaf.js
@@ -1,4 +1,4 @@
-const {clone}= require('lodash');
+const {cloneDeep}= require('lodash');
 
 module.exports = async function getLeftInLeaf(leafId){
 
@@ -13,5 +13,5 @@ module.exports = async function getLeftInLeaf(leafId){
   const identifier = leaf.meta.identifiers[0];
   const key = leaf.data.keys[0];
 
-  return clone({identifier, key })
+  return cloneDeep({identifier, key })
 }

--- a/src/adapters/FsAdapter/methods/getRightInLeaf.js
+++ b/src/adapters/FsAdapter/methods/getRightInLeaf.js
@@ -1,4 +1,4 @@
-const {clone}= require('lodash');
+const {cloneDeep}= require('lodash');
 
 module.exports = async function getRightInLeaf(leafId){
 
@@ -14,5 +14,5 @@ module.exports = async function getRightInLeaf(leafId){
   const identifier = leaf.meta.identifiers[len-1];
   const key = leaf.data.keys[len-1];
 
-  return clone({identifier, key })
+  return cloneDeep({identifier, key })
 }

--- a/src/adapters/FsAdapter/methods/saveDatabase.js
+++ b/src/adapters/FsAdapter/methods/saveDatabase.js
@@ -1,7 +1,7 @@
-const {clone} = require('lodash');
+const {cloneDeep} = require('lodash');
 
 module.exports = async function saveDatabase(){
-  const leafs = clone(this.leafs)
+  const leafs = cloneDeep(this.leafs)
   const tree = this.getParent().toJSON();
   const db = {
     leafs,

--- a/src/adapters/MemoryAdapter/methods/findInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/findInLeaf.js
@@ -26,18 +26,18 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       // const start = strictMatchingKeys[0];
       // const end = strictMatchingKeys[0] + strictMatchingKeysLen;
 
-      result.identifiers.push(...identifiers.slice(firstIdx, lastIdx+1));
-      result.keys.push(...keys.slice(firstIdx, lastIdx+1));
+      result.identifiers.push(cloneDeep(...identifiers.slice(firstIdx, lastIdx+1)));
+      result.keys.push(cloneDeep(...keys.slice(firstIdx, lastIdx+1)));
       return result;
       // return this.leafs[leafId].meta.identifiers.slice(start, end);
       break;
     case "$lte":
       let resLte = [];
-      resLte = resLte.concat(await this.findInLeaf(leafId, value, '$lt'));
-      resLte = resLte.concat(await this.findInLeaf(leafId, value, '$eq'));
+      resLte = resLte.concat(cloneDeep(await this.findInLeaf(leafId, value, '$lt')));
+      resLte = resLte.concat(cloneDeep(await this.findInLeaf(leafId, value, '$eq')));
       resLte.forEach((res) => {
-        result.identifiers.push(...res.identifiers)
-        result.keys.push(...res.keys)
+        result.identifiers.push(cloneDeep(...res.identifiers))
+        result.keys.push(cloneDeep(...res.keys))
       })
       // throw new Error('Modification to new format')
       // return resLte;
@@ -46,14 +46,14 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       if (firstIdx>-1) {
         const localIndex = keys.indexOf(value);
         if (localIndex !== 0) {
-          result.identifiers.push(...identifiers.slice(0, localIndex));
-          result.keys.push(...keys.slice(0, localIndex));
+          result.identifiers.push(cloneDeep(...identifiers.slice(0, localIndex)));
+          result.keys.push(cloneDeep(...keys.slice(0, localIndex)));
         }
         // return (localIndex===0) ? [] : this.leafs[leafId].meta.identifiers.slice(0, localIndex-1);
       } else {
         const ltKeys = lowerThanKeys(keys, value);
-        result.identifiers.push(...identifiers.slice(0, ltKeys.length));
-        result.keys.push(...keys.slice(0, ltKeys.length));
+        result.identifiers.push(cloneDeep(...identifiers.slice(0, ltKeys.length)));
+        result.keys.push(cloneDeep(...keys.slice(0, ltKeys.length)));
         // return this.leafs[leafId].meta.identifiers.slice(0, keys.length);
       }
       return result;
@@ -61,25 +61,25 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       if (firstIdx>-1) {
         const localIndex = keys.indexOf(value);
         if (localIndex !== -1) {
-          result.identifiers.push(...identifiers.slice(localIndex + strictMatchingKeysLen));
-          result.keys.push(...keys.slice(localIndex + strictMatchingKeysLen));
+          result.identifiers.push(cloneDeep(...identifiers.slice(localIndex + strictMatchingKeysLen)));
+          result.keys.push(cloneDeep(...keys.slice(localIndex + strictMatchingKeysLen)));
         }
       } else {
         const gtKeys = greaterThanKeys(keys, value);
         const len = gtKeys.length;
         if (leafId !== 0 && len > 0) {
-          result.identifiers.push(...identifiers.slice(-len));
-          result.keys.push(...keys.slice(-len));
+          result.identifiers.push(cloneDeep(...identifiers.slice(-len)));
+          result.keys.push(cloneDeep(...keys.slice(-len)));
         }
       }
       return result;
     case "$gte":
       let resGte = [];
-      resGte = resGte.concat(await this.findInLeaf(leafId, value, '$eq'));
-      resGte = resGte.concat(await this.findInLeaf(leafId, value, '$gt'));
+      resGte = resGte.concat(cloneDeep(await this.findInLeaf(leafId, value, '$eq')));
+      resGte = resGte.concat(cloneDeep(await this.findInLeaf(leafId, value, '$gt')));
       resGte.forEach((res) => {
-        result.identifiers.push(...res.identifiers)
-        result.keys.push(...res.keys)
+        result.identifiers.push(cloneDeep(...res.identifiers))
+        result.keys.push(cloneDeep(...res.keys))
       })
       // throw new Error('Modification to new format')
       // return resGte;

--- a/src/adapters/MemoryAdapter/methods/findInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/findInLeaf.js
@@ -1,6 +1,6 @@
 const lowerThanKeys = require('./ops/lowerThanKeys');
 const greaterThanKeys = require('./ops/greaterThanKeys');
-const {range}=require('lodash');
+const {cloneDeep, range}=require('lodash');
 module.exports = async function findInLeaf(leafId, value, op = '$eq') {
   const leaf = this.leafs[leafId];
 
@@ -26,8 +26,8 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       // const start = strictMatchingKeys[0];
       // const end = strictMatchingKeys[0] + strictMatchingKeysLen;
 
-      result.identifiers.push(cloneDeep(...identifiers.slice(firstIdx, lastIdx+1)));
-      result.keys.push(cloneDeep(...keys.slice(firstIdx, lastIdx+1)));
+      result.identifiers.push(...identifiers.slice(firstIdx, lastIdx+1));
+      result.keys.push(...keys.slice(firstIdx, lastIdx+1));
       return result;
       // return this.leafs[leafId].meta.identifiers.slice(start, end);
       break;
@@ -36,8 +36,8 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       resLte = resLte.concat(cloneDeep(await this.findInLeaf(leafId, value, '$lt')));
       resLte = resLte.concat(cloneDeep(await this.findInLeaf(leafId, value, '$eq')));
       resLte.forEach((res) => {
-        result.identifiers.push(cloneDeep(...res.identifiers))
-        result.keys.push(cloneDeep(...res.keys))
+        result.identifiers.push(...res.identifiers)
+        result.keys.push(...res.keys)
       })
       // throw new Error('Modification to new format')
       // return resLte;
@@ -46,14 +46,14 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       if (firstIdx>-1) {
         const localIndex = keys.indexOf(value);
         if (localIndex !== 0) {
-          result.identifiers.push(cloneDeep(...identifiers.slice(0, localIndex)));
-          result.keys.push(cloneDeep(...keys.slice(0, localIndex)));
+          result.identifiers.push(...identifiers.slice(0, localIndex));
+          result.keys.push(...keys.slice(0, localIndex));
         }
         // return (localIndex===0) ? [] : this.leafs[leafId].meta.identifiers.slice(0, localIndex-1);
       } else {
         const ltKeys = lowerThanKeys(keys, value);
-        result.identifiers.push(cloneDeep(...identifiers.slice(0, ltKeys.length)));
-        result.keys.push(cloneDeep(...keys.slice(0, ltKeys.length)));
+        result.identifiers.push(...identifiers.slice(0, ltKeys.length));
+        result.keys.push(...keys.slice(0, ltKeys.length));
         // return this.leafs[leafId].meta.identifiers.slice(0, keys.length);
       }
       return result;
@@ -61,15 +61,15 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       if (firstIdx>-1) {
         const localIndex = keys.indexOf(value);
         if (localIndex !== -1) {
-          result.identifiers.push(cloneDeep(...identifiers.slice(localIndex + strictMatchingKeysLen)));
-          result.keys.push(cloneDeep(...keys.slice(localIndex + strictMatchingKeysLen)));
+          result.identifiers.push(...identifiers.slice(localIndex + strictMatchingKeysLen))
+          result.keys.push(...keys.slice(localIndex + strictMatchingKeysLen))
         }
       } else {
         const gtKeys = greaterThanKeys(keys, value);
         const len = gtKeys.length;
         if (leafId !== 0 && len > 0) {
-          result.identifiers.push(cloneDeep(...identifiers.slice(-len)));
-          result.keys.push(cloneDeep(...keys.slice(-len)));
+          result.identifiers.push(...identifiers.slice(-len))
+          result.keys.push(...keys.slice(-len))
         }
       }
       return result;
@@ -78,8 +78,8 @@ module.exports = async function findInLeaf(leafId, value, op = '$eq') {
       resGte = resGte.concat(cloneDeep(await this.findInLeaf(leafId, value, '$eq')));
       resGte = resGte.concat(cloneDeep(await this.findInLeaf(leafId, value, '$gt')));
       resGte.forEach((res) => {
-        result.identifiers.push(cloneDeep(...res.identifiers))
-        result.keys.push(cloneDeep(...res.keys))
+        result.identifiers.push(...res.identifiers)
+        result.keys.push(...res.keys)
       })
       // throw new Error('Modification to new format')
       // return resGte;

--- a/src/adapters/MemoryAdapter/methods/getAllInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/getAllInLeaf.js
@@ -1,6 +1,6 @@
-const {clone} = require('lodash');
+const {cloneDeep} = require('lodash');
 
 module.exports = async function getAllInLeaf(leafId){
   const leaf = this.leafs[leafId];
-  return clone({identifiers:leaf.meta.identifiers, keys:leaf.data.keys })
+  return cloneDeep({identifiers:leaf.meta.identifiers, keys:leaf.data.keys })
 }

--- a/src/adapters/MemoryAdapter/methods/getDocument.js
+++ b/src/adapters/MemoryAdapter/methods/getDocument.js
@@ -1,8 +1,8 @@
-const {clone}= require('lodash');
+const {cloneDeep}= require('lodash');
 module.exports = async function getDocument(identifier) {
   const doc = this.documents[identifier];
   if (!doc) {
     return {_id: identifier};
   }
-  return clone(doc);
+  return cloneDeep(doc);
 };

--- a/src/adapters/MemoryAdapter/methods/getLeftInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/getLeftInLeaf.js
@@ -1,4 +1,4 @@
-const {clone} = require('lodash');
+const {cloneDeep} = require('lodash');
 
 module.exports = async function getLeftInLeaf(leafId){
   const leaf = this.leafs[leafId];
@@ -9,5 +9,5 @@ module.exports = async function getLeftInLeaf(leafId){
   const identifier = identifiers[0];
   const key = data.keys[0];
 
-  return clone({identifier, key })
+  return cloneDeep({identifier, key })
 }

--- a/src/adapters/MemoryAdapter/methods/getRightInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/getRightInLeaf.js
@@ -1,4 +1,4 @@
-const {clone} = require('lodash');
+const {cloneDeep} = require('lodash');
 
 module.exports = async function getRightInLeaf(leafId) {
   const leaf = this.leafs[leafId];
@@ -10,5 +10,5 @@ module.exports = async function getRightInLeaf(leafId) {
   const identifier = identifiers[len - 1];
   const key = data.keys[len - 1];
 
-  return clone({identifier, key})
+  return cloneDeep({identifier, key})
 }

--- a/src/adapters/MemoryAdapter/methods/replaceInLeaf.js
+++ b/src/adapters/MemoryAdapter/methods/replaceInLeaf.js
@@ -4,8 +4,6 @@ async function replaceInLeaf(leafId, identifier, value){
   }
   const {meta, data} = this.leafs[leafId];
 
-  console.log('replace in leaf', identifier, value)
-  console.log(meta.identifiers.includes(identifier))
   if(!meta.identifiers.includes(identifier)){
     //TODO : except unique:false?
     throw new Error(`Identifier ${identifier} do not exist`);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,3 @@
 module.exports= {
-  validTypes:['string', 'number', 'boolean']
+  validTypes:['string', 'number', 'boolean', 'object']
 }

--- a/src/types/SBFRoot/methods/insert.js
+++ b/src/types/SBFRoot/methods/insert.js
@@ -1,26 +1,23 @@
 async function insert(identifier, value = null){
   const {childrens} = this;
-  if(childrens.length===0){
 
-    // if(this.keys.length===0){
+  if(['string', 'number', 'boolean'].includes(typeof value)) {
+    if (childrens.length === 0) {
       const idx = await this.insertReferenceKey(value)
       this.identifiers.splice(idx, 0, identifier);
-    // }else{
-      // const leaf = new SBFLeaf({parent:this});
-      // this.childrens.push(leaf);
-
-      // await leaf.insert(identifier, value);
-    // }
+    } else {
+      let leafIndex = 0;
+      this.keys.forEach((_key) => {
+        if (value <= _key) return;
+        leafIndex++;
+      });
+      const leaf = childrens[leafIndex];
+      await leaf.insert(identifier, value);
+    }
   }else{
-    let leafIndex = 0;
-    this.keys.forEach((_key)=>{
-      if(value<=_key) return;
-      leafIndex++;
-    });
-    const leaf = childrens[leafIndex];
-    await leaf.insert(identifier, value);
+      throw new Error(`Unexpected insertion of type ${typeof value}`);
+    }
 
-  }
 
   if(this.isFull()){
 

--- a/src/types/SBFRoot/methods/ops/findGreaterThan.js
+++ b/src/types/SBFRoot/methods/ops/findGreaterThan.js
@@ -13,6 +13,7 @@ async function findGreaterThan(key, includeKey=false){
   let p = [];
 
   if(childrens.length===0){
+
     if(identifiers[leafIndex]){
       keys.slice(leafIndex).forEach((_key, i)=>{
         if(_key>=key){
@@ -25,6 +26,7 @@ async function findGreaterThan(key, includeKey=false){
       })
     }
   }else{
+
     // first, we lookup for all greater than matches in the actual leaf where we had our el.
     p.push(childrens[leafIndex].findGreaterThan(key, includeKey));
 
@@ -32,10 +34,10 @@ async function findGreaterThan(key, includeKey=false){
     // We need this extra step first
     let start = leafIndex+1;
     if(keys.includes(key)){
-
       p.push(childrens[start].findGreaterThan(key, includeKey));
       start+=1;
     }
+
     // All bigger leaf that our leafIndex needs to be included
     if(leafIndex<childrens.length-1){
       childrens.slice(start).forEach((child, i)=>{

--- a/src/types/SBFRoot/methods/remove.js
+++ b/src/types/SBFRoot/methods/remove.js
@@ -9,7 +9,7 @@ async function remove(remCmd){
 
   if(!childrens.length){
     const item = this.keys[leafIndex-1]
-    if(item){
+    if(item!==undefined){
       keys.splice(leafIndex-1,1)
       identifiers.splice(leafIndex-1,1)
     }

--- a/src/types/SBTree/methods/getFieldTree.js
+++ b/src/types/SBTree/methods/getFieldTree.js
@@ -1,5 +1,10 @@
 function getFieldTree(fieldName){
-  const isExcluded = this.exclude.includes(fieldName);
+  let isExcluded = this.exclude.includes(fieldName);
+
+  const splittedByDot = fieldName.split('.');
+  if(splittedByDot.length>1 && !isExcluded){
+    isExcluded = this.exclude.includes(splittedByDot[0]);
+  }
   if(isExcluded) return;
 
   return this.fieldTrees[fieldName];

--- a/src/types/SBTree/methods/insertDocuments.js
+++ b/src/types/SBTree/methods/insertDocuments.js
@@ -1,7 +1,7 @@
 const ObjectId = require('mongo-objectid');
 const insert = require('../ops/insert');
 const {waitFor} = require('../../../utils/fn');
-const {clone}= require('lodash');
+const {cloneDeep}= require('lodash');
 
 async function insertDocuments(documents) {
   // This will wait for SBTree to have isReady = true.
@@ -16,7 +16,7 @@ async function insertDocuments(documents) {
     }
     return documents;
   }
-  const document = clone(documents);
+  const document = cloneDeep(documents);
 
   if (!document._id) {
     document._id = new ObjectId().toString();

--- a/src/types/SBTree/methods/replaceDocuments.js
+++ b/src/types/SBTree/methods/replaceDocuments.js
@@ -11,6 +11,7 @@ async function replaceDocuments(documents){
     }
     return documents;
   }
+
   const currentDocument = await this.getDocument(documents._id);
   return (await replace.call(this,currentDocument, documents));
 

--- a/src/types/SBTree/methods/setFieldTree.js
+++ b/src/types/SBTree/methods/setFieldTree.js
@@ -18,7 +18,12 @@ function setFieldTree(_fieldTreeOpts){
   const {adapter} = this;
 
   const isUnique = this.uniques.includes(fieldName);
-  const isExcluded = this.exclude.includes(fieldName);
+  let isExcluded = this.exclude.includes(fieldName);
+  const splittedByDot = fieldName.split('.');
+
+  if(splittedByDot.length>1 && !isExcluded){
+    isExcluded = this.exclude.includes(splittedByDot[0]);
+  }
   if(isExcluded) return;
 
   const fieldTreeOpts = {

--- a/src/types/SBTree/ops/get.js
+++ b/src/types/SBTree/ops/get.js
@@ -1,8 +1,9 @@
+const { cloneDeep }= require('lodash');
 async function get(identifier) {
   if (!identifier) throw new Error('Expected an objectid')
 
   const res = await this.adapter.getDocument(identifier);
 
-  return res || false;
+  return cloneDeep(res) || false;
 };
 module.exports = get;

--- a/src/types/SBTree/ops/insert.js
+++ b/src/types/SBTree/ops/insert.js
@@ -1,3 +1,4 @@
+const {validTypes} = require('../../../constants');
 async function insert(document) {
   if(!document){
     throw new Error('Cannot insert empty document');
@@ -13,16 +14,43 @@ async function insert(document) {
 
     const _fieldType = typeof _fieldValue;
 
-    if (['string','number'].includes(_fieldType)) {
-      if(_fieldName !== '_id'){
-        if (!this.getFieldTree(_fieldName)) {
-          this.setFieldTree({fieldName:_fieldName});
+    if (validTypes.includes(_fieldType)) {
+      // When we have to deal with a nested object
+      if(_fieldType==='object' && !Array.isArray(_fieldType)){
+        // Then we create a nested field tree for each field of the nested object
+
+        const self = this;
+        const insertNested = async function(_fieldName, _fieldValue){
+          for(const _propName in _fieldValue){
+            if (!self.getFieldTree(`${_fieldName}.${_propName}`)) {
+              self.setFieldTree({fieldName:`${_fieldName}.${_propName}`});
+            }
+            const fieldTree = self.getFieldTree(`${_fieldName}.${_propName}`);
+            if(fieldTree){
+              if(typeof _fieldValue[_propName] === 'object' && !Array.isArray(_fieldValue)){
+                for(const _childPropName in _fieldValue[_propName]){
+                  await insertNested(`${_fieldName}.${_propName}`, _fieldValue[_propName]);
+                }
+              }else{
+                await fieldTree.insert(id, _fieldValue[_propName]);
+              }
+            }
+          }
         }
-        const fieldTree = this.getFieldTree(_fieldName);
-        if(fieldTree){
-          await fieldTree.insert(id, _fieldValue);
+
+        await insertNested(_fieldName, _fieldValue);
+      }else{
+        if(_fieldName !== '_id'){
+          if (!this.getFieldTree(_fieldName)) {
+            this.setFieldTree({fieldName:_fieldName});
+          }
+          const fieldTree = this.getFieldTree(_fieldName);
+          if(fieldTree){
+            await fieldTree.insert(id, _fieldValue);
+          }
         }
       }
+
     }else{
       this.verbose && console.log(`No index for ${_fieldName} : Typeof ${_fieldType} : ${JSON.stringify(_fieldValue)}`)
     }

--- a/src/types/SBTree/ops/query.js
+++ b/src/types/SBTree/ops/query.js
@@ -20,7 +20,25 @@ const findIntersectingIdentifiers = (listOfListOfIdentifiers) => {
   return intersection(...identifiers);
 }
 
+
+
 async function query(query) {
+  const self = this;
+  const findNested = function(_promises, _queryFieldName, _queryFieldValue) {
+    for(const nestedQueryFieldName in _queryFieldValue){
+      const nestedQueryFieldValue = _queryFieldValue[nestedQueryFieldName];
+      const nestedQueryFieldType = typeof nestedQueryFieldValue;
+
+      if(['number','string','boolean'].includes(nestedQueryFieldType)){
+        _promises.push(self.getFieldTree(`${_queryFieldName}.${nestedQueryFieldName}`).find(nestedQueryFieldValue, '$eq'));
+      }else if (nestedQueryFieldType==='object' && !Array.isArray(nestedQueryFieldValue)){
+        findNested(_promises, `${_queryFieldName}.${nestedQueryFieldName}`, nestedQueryFieldValue);
+      }else{
+        throw new Error(`Not supported type : ${nestedQueryFieldType}`);
+      }
+    }
+  };
+
   const fields = Object.keys(query);
   const fieldsResults = {};
   const result = [];
@@ -31,17 +49,22 @@ async function query(query) {
   }
 
   const promises = [];
+
   fields.forEach((queryFieldName) => {
+
     const queryFieldValue = query[queryFieldName];
-    const fieldTree = this.getFieldTree(queryFieldName);
-    if (!fieldTree) {
-      return;
-    }
     const queryFieldType = typeof queryFieldValue;
+
+    let fieldTree;
+
     switch (queryFieldType) {
       case "number":
       case "boolean":
       case "string":
+        fieldTree = this.getFieldTree(queryFieldName);
+        if (!fieldTree) {
+          return;
+        }
         promises.push(fieldTree.find(queryFieldValue, '$eq'));
         break;
       case "object":
@@ -51,10 +74,13 @@ async function query(query) {
           const operators = Object.keys(queryFieldValue).filter((el) => el[0] === '$');
 
           if (operators.length === 0) {
-            throw new Error(`Not supported object query with no operator. Please open a Github issue to specify your need.`);
-          }
-          for(const operator of operators){
-            promises.push(fieldTree.find(queryFieldValue[operator], operator));
+            // Then we iterate on values to perform find on all trees of nested object
+            findNested(promises, queryFieldName, queryFieldValue)
+          }else{
+            fieldTree = this.getFieldTree(queryFieldName);
+            for(const operator of operators){
+              promises.push(fieldTree.find(queryFieldValue[operator], operator));
+            }
           }
         }
         break;

--- a/src/types/SBTree/ops/query.js
+++ b/src/types/SBTree/ops/query.js
@@ -1,4 +1,4 @@
-const {intersection} = require('lodash');
+const {cloneDeep, intersection} = require('lodash');
 
 const get = require('./get');
 
@@ -105,8 +105,8 @@ async function query(query) {
       });
 
   const matchingObjectIds = findIntersectingIdentifiers(intermediateIdentifiers);
+
   return resolveDocuments(this, matchingObjectIds);
-  return result;
 }
 
 module.exports = query;

--- a/src/types/SBTree/ops/query.js
+++ b/src/types/SBTree/ops/query.js
@@ -1,4 +1,4 @@
-const {cloneDeep, intersection} = require('lodash');
+const {intersection} = require('lodash');
 
 const get = require('./get');
 
@@ -105,7 +105,6 @@ async function query(query) {
       });
 
   const matchingObjectIds = findIntersectingIdentifiers(intermediateIdentifiers);
-
   return resolveDocuments(this, matchingObjectIds);
 }
 

--- a/src/types/SBTree/ops/remove.js
+++ b/src/types/SBTree/ops/remove.js
@@ -3,6 +3,25 @@ const query = require('./query')
 const RemoveCommand = require('./RemoveCommand');
 
 async function remove(_query) {
+  const self = this;
+  const removeNestedProp = async function (_fieldName, _fieldValue, _remCmd) {
+    const _fieldValueType = typeof _fieldValue;
+    console.log({_fieldName}, {_fieldValue})
+    if(['number','string','boolean'].includes(_fieldValueType)){
+      const fieldNode = self.getFieldTree(_fieldName);
+      await fieldNode.remove(_remCmd);
+    }else{
+      if(_fieldValueType==='object' && !Array.isArray(_fieldValue)){
+        for (const _nestedFieldName in _fieldValue) {
+          const _nestedFieldValue = _fieldValue[_nestedFieldName];
+          await removeNestedProp(`${_fieldName}.${_nestedFieldName}`, _nestedFieldValue, _remCmd);
+        }
+      }else{
+        throw new Error(`Unsupported type ${_fieldValueType}`)
+      }
+    }
+
+  }
   const results = await query.call(this, _query)
   for (const result of results) {
     //TODO : This can be improved.
@@ -10,9 +29,22 @@ async function remove(_query) {
     // We would need less computation to perform the deletion task.
     const remCmd = new RemoveCommand(result);
     for (const _fieldName of remCmd.fields) {
-        const fieldNode = this.getFieldTree(_fieldName);
+      const _fieldValue =  remCmd.query[_fieldName];
+      const _fieldValType = typeof _fieldValue;
 
-        await fieldNode.remove(remCmd);
+        if(['number','string','boolean'].includes(_fieldValType)){
+          const fieldNode = this.getFieldTree(_fieldName);
+          await fieldNode.remove(remCmd);
+        }else{
+          if(_fieldValType==='object' && !Array.isArray(_fieldValue)){
+            for (const _nestedFieldName in _fieldValue) {
+              const _nestedFieldValue = _fieldValue[_nestedFieldName];
+              await removeNestedProp(`${_fieldName}.${_nestedFieldName}`,  _nestedFieldValue, remCmd);
+            }
+          }else{
+            throw new Error(`Unsupported type ${_fieldValType}`)
+          }
+        }
 
         // Remove documents
         await (this.getAdapter()).removeDocument(remCmd._id);

--- a/src/types/SBTree/ops/replace.js
+++ b/src/types/SBTree/ops/replace.js
@@ -53,7 +53,6 @@ async function replace(currentDocument, newDocument) {
         }
         const fieldTree = this.getFieldTree(_addedFieldName);
         if(fieldTree){
-          console.log('inserted', _addedFieldValue, _addedFieldName,id)
           await fieldTree.insert(id, _addedFieldValue);
         }
       }

--- a/src/types/SBTree/ops/replace.js
+++ b/src/types/SBTree/ops/replace.js
@@ -47,7 +47,6 @@ async function replace(currentDocument, newDocument) {
   const changedField = findChangedFields(newDocument, currentDocument);
   const deletedFields = findDeletedFields(newDocument, currentDocument);
 
-  console.log(addedFields)
   // We add all extra fields
   for (const _addedFieldName in addedFields) {
     const _addedFieldValue = newDocument[_addedFieldName];
@@ -93,8 +92,8 @@ async function replace(currentDocument, newDocument) {
       this.verbose && console.log(`No index for ${_deletedFieldName} : Typeof ${_deletedFieldType} : ${JSON.stringify(_deletedFieldValue)}`)
     }
   }
-
-
+  // Sorry. But was the easiest and quickiest way to do nested things.
+  // Will refactor, hopefully.
   const replaceProp = async function (_fieldName, _fieldValue) {
     const _fieldType = typeof _fieldValue;
     if (['number', 'string', 'boolean'].includes(_fieldType)) {
@@ -124,7 +123,7 @@ async function replace(currentDocument, newDocument) {
         await replaceProp(`${_fieldName}.${_nestedFieldName}`,  _fieldValue[_nestedFieldName]);
       }
     } else {
-      throw new Error(`Not supported type : ${nestedFieldType}`);
+      throw new Error(`Not supported type : ${_fieldType}`);
     }
   }
 

--- a/test/e2e/use.case.2.js
+++ b/test/e2e/use.case.2.js
@@ -21,10 +21,9 @@ describe('E2E - Classic UseCase', function suite() {
       const doc = await customTree.findDocuments({name:"Alex"});
       expect(doc).to.deep.equal([alex])
     });
-    it('should not be able to find document on nested',async function () {
-      // May be we should warn user in some way ?
+    it('should be able to find document on nested',async function () {
       const doc = await customTree.findDocuments({infos:{job:{sector:"IT"}}});
-      expect(doc).to.deep.equal([]);
+      expect(doc).to.deep.equal([alex]);
     });
   });
 })

--- a/test/unit/types/SBTree/ops/insert.js
+++ b/test/unit/types/SBTree/ops/insert.js
@@ -51,6 +51,10 @@ describe('SBTree - ops - insert', () => {
       ['setFieldTree', 'email'],
       ['getFieldTree', 'email'],
 
+      ['getFieldTree', 'address.country'],
+      ['setFieldTree', 'address.country'],
+      ['getFieldTree', 'address.country'],
+
       // Address is not called as we discard it (type is object)
       ['savedDocument', '5d6ebb7e21f1df6ff7482631'],
     ]);


### PR DESCRIPTION
### Issue being fixed or implemented  

This Pull request brings, finally, the ability to deal with nested object. 
It does it by creating additional SBFTree store in SBTree.fieldTrees, using dot-notation. 
As such `user:{firstname:"Alex",country:{iso:'fr'}}`; will results in SBFTree(user).fieldTrees having 
`firstname`, `country` and `country.iso`.
It handles find / replace / remove. 

### What was done  

- feat : added nested object support (find/insert/remove/replace).
- fix: used cloneDeep instead of clone

