### PR TITLE
fix: Tree filled lower than order is not searchable

### DIFF
--- a/src/types/SBFRoot/methods/ops/findLowerThan.js
+++ b/src/types/SBFRoot/methods/ops/findLowerThan.js
@@ -13,6 +13,7 @@ async function findLowerThan(key, includeKey = false) {
   let p = [];
 
   if(childrens.length===0){
+    leafIndex--;
     if(identifiers[leafIndex]){
       const last = keys.lastIndexOf(key);
 


### PR DESCRIPTION
### Issue being fixed or implemented  

As of now if the tree is filled less then order size, one cannot search/delete/replace documents if using $lte to query. Example code:
```js
const {SBTree} = require('sbtree');
const tree = new SBTree({order: 3});

(async()=>{
    await tree.insertDocuments({
        doc_id: '754aeea7c0919797d6eb2710d200eafd',
        key: 'VATEmq',
        value: 4,
        ts: 1588913801357
    })
    const t1 = new Date().getTime()-10000;
    console.log(t1, typeof t1);
    console.log(1588913801357<t1);
    console.log(await tree.deleteDocuments({ts: {$lte: t1}}))
})().then(v=>{
    console.log("Complete");
})
```
In above code, we create a tree with order size three and filled it with only one elements.
Now if we delete the document using query `{ts: {$lte:t1}} , the single documents though valid for deletio is not found out and deleted/

### What was done  
The problem seems to be occuring due to leafIndex incrementation below order level.
Have applied a decrement operation to balance the mismatch.

### How Has This Been Tested?
Have re-run the sample code, which failed.

### Notes  


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
