### PR TITLE
fix: issue with lower fill factor than order for single element tree

### DIFF
--- a/src/types/SBFRoot/methods/ops/findLowerThan.js
+++ b/src/types/SBFRoot/methods/ops/findLowerThan.js
@@ -13,6 +13,7 @@ async function findLowerThan(key, includeKey = false) {
   let p = [];
 
   if(childrens.length===0){
+    leafIndex--;
     if(identifiers[leafIndex]){
       const last = keys.lastIndexOf(key);
 

--- a/src/types/SBFRoot/methods/ops/findLowerThan.js
+++ b/src/types/SBFRoot/methods/ops/findLowerThan.js
@@ -1,6 +1,6 @@
 async function findLowerThan(key, includeKey = false) {
   let result = {identifiers: [], keys: []};
-  const {childrens,identifiers, keys} = this;
+  const { childrens, identifiers, keys } = this;
 
   // We first see where our key is located;
   let leafIndex = 0;
@@ -12,24 +12,24 @@ async function findLowerThan(key, includeKey = false) {
 
   let p = [];
 
-  if(childrens.length===0){
+  if (childrens.length === 0) {
     if(!identifiers[leafIndex]){
-    leafIndex--;
+      leafIndex--;
     }
     if (identifiers[leafIndex]) {
       const last = keys.lastIndexOf(key);
-
-      keys.slice(0, last+1 || leafIndex+1).forEach((_key, i)=>{
-        if(_key<=key){
-          if(_key === key && !includeKey){
+      keys.slice(0, last + 1 || leafIndex + 1).forEach((_key, i) => {
+        if (_key <= key) {
+          if (_key === key && !includeKey) {
             return;
           }
+
           result.identifiers.push(identifiers[i])
           result.keys.push(keys[i])
         }
       })
     }
-  }else{
+  } else {
     // All smaller leaf that our leafIndex needs to be included
     if (leafIndex >= 1) {
       childrens.slice(0, leafIndex).forEach((child) => {

--- a/src/types/SBFRoot/methods/ops/findLowerThan.js
+++ b/src/types/SBFRoot/methods/ops/findLowerThan.js
@@ -13,8 +13,10 @@ async function findLowerThan(key, includeKey = false) {
   let p = [];
 
   if(childrens.length===0){
+    if(!identifiers[leafIndex]){
     leafIndex--;
-    if(identifiers[leafIndex]){
+    }
+    if (identifiers[leafIndex]) {
       const last = keys.lastIndexOf(key);
 
       keys.slice(0, last+1 || leafIndex+1).forEach((_key, i)=>{

--- a/test/e2e/use.case.4.js
+++ b/test/e2e/use.case.4.js
@@ -1,0 +1,59 @@
+const {expect} = require('chai');
+const {SBTree} = require('../..');
+const users = require('./users');
+
+const toNames = (arr)=>{
+  return arr.reduce((acc, el)=>{
+      acc.push(el.name);
+      return acc
+    },[]);
+}
+describe('E2E - UseCase with lower fill factor than order', function suite() {
+  let ts = 1588913801357;
+  describe('RegUser DB', async () => {
+    const customTree = new SBTree({order:40});
+    const doc =  {
+     _id: '754aeea7c0919797d6eb2710d200eafd',
+     key: 'VATEmq',
+     value: 4,
+     ts
+   };
+
+    it('should insert', async function () {
+      await customTree.insertDocuments(doc);
+    });
+    it('should get document', async function () {
+      const res = await customTree.getDocument('754aeea7c0919797d6eb2710d200eafd')
+      expect(res).to.deep.equal(doc);
+    });
+    it('should be able to search the document', async function () {
+      const found = await customTree.findDocuments({ts});
+      expect(found).to.deep.equal([doc]);
+
+      const foundLowerThanEq = await customTree.findDocuments({ts:{$lte: ts}});
+      expect(foundLowerThanEq).to.deep.equal([doc]);
+
+      const foundLowerThanEq1 = await customTree.findDocuments({ts:{$lte: ts+1000}});
+      expect(foundLowerThanEq1).to.deep.equal([doc]);
+
+      const foundGreaterThanEq = await customTree.findDocuments({ts:{$gte: ts}});
+      expect(foundGreaterThanEq).to.deep.equal([doc]);
+
+      const foundGreaterThanEq1 = await customTree.findDocuments({ts:{$gte: ts-1000}});
+      expect(foundGreaterThanEq1).to.deep.equal([doc]);
+
+      const foundEq = await customTree.findDocuments({ts:{$eq: ts}});
+      expect(foundEq).to.deep.equal([doc]);
+    });
+    it('should be able to delete the document', async function () {
+      const deleted = await customTree.deleteDocuments({ts: {$lte: ts+1}});
+      expect(deleted).to.deep.equal([doc]);
+
+      const found = await customTree.findDocuments({ts});
+      expect(found).to.deep.equal([]);
+
+      const res = await customTree.getDocument('754aeea7c0919797d6eb2710d200eafd')
+      expect(res).to.deep.equal({});
+    });
+  });
+})


### PR DESCRIPTION
### Issue being fixed or implemented  

As of now if the tree is filled less then order size, one cannot search/delete/replace documents if using $lte to query. Example code:
```js
const {SBTree} = require('sbtree');
const tree = new SBTree({order: 3});

(async()=>{
    await tree.insertDocuments({
        doc_id: '754aeea7c0919797d6eb2710d200eafd',
        key: 'VATEmq',
        value: 4,
        ts: 1588913801357
    })
    const t1 = new Date().getTime()-10000;
    console.log(t1, typeof t1);
    console.log(1588913801357<t1);
    console.log(await tree.deleteDocuments({ts: {$lte: t1}}))
})().then(v=>{
    console.log("Complete");
})
```
In above code, we create a tree with order size three and filled it with only one elements.
Now if we delete the document using query `{ts: {$lte:t1}} , the single documents though valid for deletio is not found out and deleted/

### What was done  
The problem seems to be occuring due to leafIndex incrementation below order level.
Have applied a decrement operation to balance the mismatch.

### How Has This Been Tested?

Added tests case for lower tree actual size than order.
Using current test suite.

### Notes  

Thank you to @anuragvohraec for the issue and fix !

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation