### PR TITLE
fix: consistency issue with getDocument on unfound doc

### DIFF
--- a/src/adapters/MemoryAdapter/methods/getDocument.js
+++ b/src/adapters/MemoryAdapter/methods/getDocument.js
@@ -2,7 +2,7 @@ const {cloneDeep}= require('lodash');
 module.exports = async function getDocument(identifier) {
   const doc = this.documents[identifier];
   if (!doc) {
-    return {_id: identifier};
+    return {};
   }
   return cloneDeep(doc);
 };


### PR DESCRIPTION
### Issue being fixed or implemented  

When we require a document by it's ID that do not exist, with the MemoryAdapter, the response looks like : 

```js
> getDocument('754aeea7c0919797d6eb2710d200eafd') 
{
   "_id": "754aeea7c0919797d6eb2710d200eafd"
}
```

While the FS adapter will return an empty object ({});. 

### What was done  

Removed the `_id` field from return object of unfound document.

### How Has This Been Tested?

Using current test suite.

### Notes  

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
