### PR TITLE
feat: add isReady method + remove waitFor deps

### DIFF
--- a/src/adapters/FsAdapter/methods/loadDatabase.js
+++ b/src/adapters/FsAdapter/methods/loadDatabase.js
@@ -4,18 +4,20 @@ const {each} = require('lodash');
 module.exports = async function loadDatabase() {
   const job = await this.queue.add('File.read', `${this.path}/sbtree.meta`);
   await job.execution();
-  const db = job.results;
-  const {
-    leafs,
-    tree
-  } = db;
+  const db = job.result;
+  if(db){
+    const {
+      leafs,
+      tree
+    } = db;
 
-  if (tree) {
-    each(leafs, (leaf, leafName) => {
-      this.leafs[leafName] = {name: leafName, meta: new LeafMeta(leaf.meta)};
-    })
+    if (tree) {
+      each(leafs, (leaf, leafName) => {
+        this.leafs[leafName] = {name: leafName, meta: new LeafMeta(leaf.meta)};
+      })
 
-    await this.getParent().loadState(tree);
+      await this.getParent().loadState(tree);
+    }
   }
 
   this.isReady = true;

--- a/src/adapters/FsAdapter/methods/ops/autosave.js
+++ b/src/adapters/FsAdapter/methods/ops/autosave.js
@@ -4,7 +4,9 @@ module.exports = async function autosave(self){
       await self.saveDatabase();
     }
     setTimeout(async ()=>{
-      await next(self);
+      if(self.autoSave){
+        await next(self);
+      }
     }, self.autoSaveInterval)
   }
   await next(self);

--- a/src/types/SBTree/SBTree.js
+++ b/src/types/SBTree/SBTree.js
@@ -1,7 +1,6 @@
 const EventEmitter = require('events');
 const {MemoryAdapter, FsAdapter} = require('../../adapters');
 const {generateTreeId} = require('../../utils/crypto');
-const {waitFor} = require('../../utils/fn');
 const {each}=require('lodash');
 // const SBFTree = require('../SBFTree/SBFTree');
 
@@ -35,13 +34,16 @@ class SBTree extends EventEmitter {
       exclude:[],
       uniques:[],
     };
+
+    this.state = {
+      isReady: true
+    }
     this.adapter = (props.adapter) ? parseAdapter(props.adapter) : new MemoryAdapter();
-    this.isReady = true;
 
     if(this.adapter.name !== 'MemoryAdapter'){
       // We will need to sync up first
-      this.isReady = false;
-      waitFor(self.adapter,'isReady', ()=> self.isReady = true);
+      this.state.isReady = false;
+      self.adapter.on('ready', ()=> self.state.isReady = true);
     }
 
     this.order= (props.order) ? props.order : defaultProps.order;
@@ -84,10 +86,10 @@ class SBTree extends EventEmitter {
     }
   }
   async isReady() {
-    return new Promise(((resolve) => {
+    return new Promise((resolve) => {
       if (this.state.isReady) return resolve(true);
       this.on('ready', () => resolve(true));
-    }));
+    });
   }
 }
 

--- a/src/types/SBTree/SBTree.js
+++ b/src/types/SBTree/SBTree.js
@@ -83,6 +83,12 @@ class SBTree extends EventEmitter {
       order, fillFactor, verbose
     }
   }
+  async isReady() {
+    return new Promise(((resolve) => {
+      if (this.state.isReady) return resolve(true);
+      this.on('ready', () => resolve(true));
+    }));
+  }
 }
 
 

--- a/src/types/SBTree/methods/deleteDocuments.js
+++ b/src/types/SBTree/methods/deleteDocuments.js
@@ -1,13 +1,12 @@
 const remove = require('../ops/remove');
-const {waitFor} = require('../../../utils/fn');
 
 async function deleteDocuments(query){
   if(!query || query === {}){
     // this would cause to delete all as we would query all.
     throw new Error('Invalid query')
   }
-  if(!this.isReady){
-    await waitFor(this, 'isReady');
+  if(!this.state.isReady){
+    await this.isReady();
   }
 
   return (await remove.call(this,query));

--- a/src/types/SBTree/methods/findDocuments.js
+++ b/src/types/SBTree/methods/findDocuments.js
@@ -1,10 +1,10 @@
 const query = require('../ops/query');
-const {waitFor} = require('../../../utils/fn');
 
 async function findDocuments(params){
-  if(!this.isReady){
-    await waitFor(this, 'isReady');
+  if(!this.state.isReady){
+    await this.isReady();
   }
+
   return (await query.call(this,params));
 
 };

--- a/src/types/SBTree/methods/getDocument.js
+++ b/src/types/SBTree/methods/getDocument.js
@@ -1,9 +1,8 @@
 const get = require('../ops/get');
-const {waitFor} = require('../../../utils/fn');
 
 async function getDocument(identifier){
-  if(!this.isReady){
-    await waitFor(this, 'isReady');
+  if(!this.state.isReady){
+    await this.isReady();
   }
 
   return (await get.call(this,identifier));

--- a/src/types/SBTree/methods/insertDocuments.js
+++ b/src/types/SBTree/methods/insertDocuments.js
@@ -1,13 +1,12 @@
 const ObjectId = require('mongo-objectid');
 const insert = require('../ops/insert');
-const {waitFor} = require('../../../utils/fn');
 const {cloneDeep}= require('lodash');
 
 async function insertDocuments(documents) {
   // This will wait for SBTree to have isReady = true.
   // When so, it will then perform the insertion.
-  if(!this.isReady){
-    await waitFor(this, 'isReady');
+  if(!this.state.isReady){
+    await this.isReady();
   }
 
   if (Array.isArray(documents)) {

--- a/src/types/SBTree/methods/replaceDocuments.js
+++ b/src/types/SBTree/methods/replaceDocuments.js
@@ -1,9 +1,8 @@
 const replace = require('../ops/replace');
-const {waitFor} = require('../../../utils/fn');
 
 async function replaceDocuments(documents){
-  if(!this.isReady){
-    await waitFor(this, 'isReady');
+  if(!this.state.isReady){
+    await this.isReady();
   }
   if (Array.isArray(documents)) {
     for (const document of documents) {

--- a/src/types/SBTree/methods/updateDocuments.js
+++ b/src/types/SBTree/methods/updateDocuments.js
@@ -1,9 +1,8 @@
 const query = require('../ops/query');
-const {waitFor} = require('../../../utils/fn');
 
 async function findDocuments(params){
-  if(!this.isReady){
-    await waitFor(this, 'isReady');
+  if(!this.state.isReady){
+    await this.isReady();
   }
   return (await query.call(this,params));
 

--- a/test/unit/types/SBTree/SBTree.js
+++ b/test/unit/types/SBTree/SBTree.js
@@ -17,6 +17,17 @@ describe('SBTree', () => {
     expect(tree.fieldTrees).to.deep.equal({});
     expect(tree.size).to.equal(0);
   });
+  it('should provide isReady ', async function () {
+    const treeNeedReadiness = new SBTree({adapter: {name:'FsAdapter'}});
+    expect(treeNeedReadiness.state.isReady).to.equal(false);
+    await treeNeedReadiness.isReady();
+    expect(treeNeedReadiness.state.isReady).to.equal(true);
+
+    // Both of these are done to release any interval working
+    treeNeedReadiness.adapter.autoSave = false;
+    treeNeedReadiness.adapter.queue.stop();
+  });
+  return;
   it('should correctly default', function () {
     const t = new SBTree();
     expect(t.order).to.equal(511)


### PR DESCRIPTION
### Issue being fixed or implemented  

In order to avoid having to deal with an interval on awaiting readiness, we need to use event instead. 

### What was done  

Please include a summary of the change

- fix: breaking change of our FSLock dependency. 
- impr: add isReady method 
- impr: moved out from waitFor to isReady

### How Has This Been Tested?

- Added a new test for isReady (using FsAdapter)
