### PR TITLE
fix: handle field value as null

### DIFF
--- a/src/types/SBTree/utils/getFieldNamesFromQuery.js
+++ b/src/types/SBTree/utils/getFieldNamesFromQuery.js
@@ -3,7 +3,7 @@ module.exports = function getFieldNamesFromQuery(query) {
   Object.entries(query).forEach((field) => {
     let fieldName = field[0];
     if (fieldName[0] === '$') return;
-
+    if (field[1] === null) return;
     if (field[1].constructor === Object) {
       const _fields = getFieldNamesFromQuery(field[1]);
       if (_fields[0]) {


### PR DESCRIPTION
### Issue being fixed or implemented  

Upon find of an object such as {a: "something", b: undefined, c: null}, it would fail the find.

### What was done  

Return null instead of failing. 

### How Has This Been Tested?
